### PR TITLE
refactor: improve datasource handling and project context management

### DIFF
--- a/apps/web/app/routes/project/datasources/index.tsx
+++ b/apps/web/app/routes/project/datasources/index.tsx
@@ -23,7 +23,7 @@ export default function ProjectDatasourcesPage({
     workspace.projectId as string,
   );
 
-  const hasDatasources = datasources.data?.length ?? 0 > 0;
+  const hasDatasources = (datasources.data?.length ?? 0) > 0;
 
   return (
     <div className="p-2 lg:p-4">


### PR DESCRIPTION
## 🐛 Datasource persistence on creation: fix bug

## Related Issue

Closes #22

## What

- The datasource list never refreshed after a create, forcing a reload to see new entries.
- The empty-state guard on the list page was incorrect, so it sometimes rendered the wrong UI branch.
- After saving, the flow bounced users to the notebook instead of the datasource list.

## How

- Tapped into `workspace.projectId`/`workspace.userId` inside `apps/web/app/routes/project/datasources/new.tsx`, with a guard + toast when the project context is missing.
- Invalidated `getDatasourcesByProjectIdKey` via `queryClient.invalidateQueries` right after persisting to IndexedDB so the list refetches instantly.

## Review Guide

1. `apps/web/app/routes/project/datasources/new.tsx` – end-to-end flow: context usage, persistence, cache invalidation, redirect.
2. `apps/web/app/routes/project/datasources/index.tsx` – single-line fix for the empty-state check.

## Testing

- [x] Manual testing performed (create datasource, ensure redirect + instant list refresh, verify empty state)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated

## Documentation

- [ ] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)

## User Impact

- Datasources now persist against the correct project/user, show up immediately in the list, and keep the user within the datasource surface.

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`pnpm test`)
- [x] Lint passes (`pnpm lint:fix`)
- [x] Type check passes (`pnpm typecheck`)
- [x] This PR can be safely reverted if needed
