### PR TITLE
fix(chat): stabilize conversation message rendering

### DIFF
--- a/apps/web/app/routes/project/_components/agent-ui-wrapper.tsx
+++ b/apps/web/app/routes/project/_components/agent-ui-wrapper.tsx
@@ -305,6 +305,11 @@ export const AgentUIWrapper = forwardRef<
     [conversationSlug],
   );
 
+  const convertedInitialMessages = useMemo(
+    () => convertMessages(initialMessages),
+    [initialMessages],
+  );
+
   // Handle sendMessage and model from QweryAgentUI
   // eslint-disable react-hooks/preserve-manual-memoization -- React Compiler warning about dependency inference
   const handleSendMessageReady = useCallback(
@@ -649,7 +654,7 @@ export const AgentUIWrapper = forwardRef<
   return (
     <QweryAgentUI
       transport={transport}
-      initialMessages={convertMessages(initialMessages)}
+      initialMessages={convertedInitialMessages}
       models={SUPPORTED_MODELS as { name: string; value: string }[]}
       usage={convertUsage(usage)}
       emitFinish={handleEmitFinish}

--- a/apps/web/lib/queries/use-get-messages.ts
+++ b/apps/web/lib/queries/use-get-messages.ts
@@ -25,7 +25,9 @@ export function useGetMessagesByConversationSlug(
       );
       return useCase.execute({ conversationSlug: slug });
     },
-    staleTime: 30 * 1000,
+    staleTime: 2 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
     enabled:
       options?.enabled !== undefined ? options.enabled && !!slug : !!slug,
     refetchInterval: options?.refetchInterval,


### PR DESCRIPTION
## Related Issue
Closes #145
## What
Fixes a regression where conversation messages could disappear or render inconsistently after switching tabs or returning after a short wait.
This issue was caused by aggressive query refetch behavior combined with UI state reconciliation that could overwrite local message state during transient empty/refresh states.
## How
The fix stabilizes both query freshness behavior and message reconciliation flow:
- `apps/web/lib/queries/use-get-messages.ts`
  - Increased `staleTime` to reduce unnecessary immediate refetch churn.
  - Disabled `refetchOnWindowFocus` and `refetchOnReconnect` for this query to avoid destructive refresh timing during tab switching/reconnects.
- `packages/ui/src/qwery/agent-ui.tsx`
  - Reset behavior now keys off conversation slug changes (intentional context switches) rather than transient data states.
  - Prevented destructive clears when `initialMessages` is temporarily empty during refetch.
  - Avoided overwriting local unsynced/in-flight UI messages with stale server snapshots.
- `apps/web/app/routes/project/_components/agent-ui-wrapper.tsx`
  - Memoized `convertMessages(initialMessages)` to avoid repeated object churn and unnecessary downstream reconciliation triggers.

## Review Guide
1. Start with `apps/web/lib/queries/use-get-messages.ts` (query refetch policy changes)
2. Then review `packages/ui/src/qwery/agent-ui.tsx` (core reconciliation/guard logic)
3. Finish with `apps/web/app/routes/project/_components/agent-ui-wrapper.tsx` (memoization support)
## Testing
- [x] Manual testing performed (conversation switch, wait, return to active conversation, verify messages remain visible)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] Targeted type checks run:
  - `pnpm --filter web typecheck`
  - `pnpm --filter @qwery/ui typecheck`
 Documentation
- [ ] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)
## User Impact
Users no longer see conversation history flicker/disappear after tab switches or reconnect/focus events.
- Improves reliability and trust in chat history rendering.
- No breaking API or data model changes.
- Behavior is backward compatible and safely revertible.
## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`pnpm test`)
- [x] Lint passes (`pnpm lint:fix`)
- [x] Type check passes (`pnpm typecheck`)
- [x] This PR can be safely reverted if needed
