### PR TITLE
docs: clarify server bind host env var

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,23 +80,15 @@ The web app will be available at `http://localhost:3000`
 
 On some systems, the `HOSTNAME` environment variable contains your PC name (for example `my-laptop`) instead of a bind address, which can make the server unreachable from other devices.
 
-To force a proper bind address, set `SERVER_HOST` explicitly before starting the server.
+To force a proper bind address, set `HOSTNAME` explicitly before starting the server.
 
 Example:
 
 ```bash
-SERVER_HOST=0.0.0.0 pnpm --filter server dev
+HOSTNAME=0.0.0.0 pnpm --filter server dev
 ```
 
 Use `0.0.0.0` when you want the server reachable from your local network.
-
-If the web app still shows `TypeError: fetch failed`, set `SERVER_API_URL` to the correct server host.
-
-```bash
-SERVER_API_URL=http://<your-server-host>:4096/api
-```
-
-Set it in `apps/server/.env` (or your local env override).
 
 ### Desktop Application
 


### PR DESCRIPTION
## Related Issue
N/A

## What
Clarifies server host binding guidance in the root README so local/network access setup is explicit and less error-prone.

## How
- `README.md`
  - documents using `HOSTNAME=0.0.0.0` when you need the server to bind to a reachable interface
  - keeps the section focused on host binding and trims extra troubleshooting noise

## Review Guide
1. Review `README.md` host binding section changes
2. Confirm the wording is accurate for local development and LAN reachability

## Testing
- [x] Manual testing performed (validated docs instructions against local setup expectations)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [x] `pnpm test` passes locally
- [x] `pnpm lint:fix` passes locally

## Documentation
- [x] README updated
- [ ] CHANGELOG.md updated (if applicable)

## User Impact
- Reduces confusion around why the server may not be reachable from other devices/processes.
- Improves first-run success for local and networked development setups.
- No runtime behavior changes (documentation-only update).

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`pnpm test`)
- [x] Lint passes (`pnpm lint:fix`)
- [x] This PR can be safely reverted if needed