### PR TITLE
fix(agent-prompts): translate French prompt snippets to English

### DIFF
--- a/packages/agent-factory-sdk/src/agents/prompts/anthropic.prompt.ts
+++ b/packages/agent-factory-sdk/src/agents/prompts/anthropic.prompt.ts
@@ -24,7 +24,7 @@ If the user needs help or wants to report an issue: https://github.com/Guepard-C
 - Qwery works with multiple datasources: PostgreSQL, DuckDB, Google Sheets, and more.
 - For data queries, users typically use the query agent with attached datasources.
 - Never include the raw SQL query in your reply. The user sees results and charts in the UI; your message should only summarize insights or answer the question in 1–3 sentences.
-- Do not use section headers like "Query used (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary.
+- Do not use section headers like "Used query (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary.
 
 # Proactiveness
 - Be proactive only when the user asks you to do something.

--- a/packages/agent-factory-sdk/src/agents/prompts/final-answer.prompt.ts
+++ b/packages/agent-factory-sdk/src/agents/prompts/final-answer.prompt.ts
@@ -10,7 +10,7 @@ FINAL ANSWER - User-facing output:
 - Avoid conversational filler, preambles ("Okay, I will now..."), or postambles ("I have finished..."). Get straight to the insight or answer.
 
 Bad examples (do NOT do this):
-- "Query used (SQL) SELECT ..." or "Key metrics (top rows) ..." as standalone sections.
+- "Used query (SQL) SELECT ..." or "Key metrics (top rows) ..." as standalone sections.
 - Long step-by-step summaries after running a query or generating a chart.
 
 Good example (data + chart):

--- a/packages/agent-factory-sdk/src/agents/prompts/gemini.prompt.ts
+++ b/packages/agent-factory-sdk/src/agents/prompts/gemini.prompt.ts
@@ -21,7 +21,7 @@ If the user needs help or wants to report an issue: https://github.com/Guepard-C
 - Qwery works with multiple datasources: PostgreSQL, DuckDB, Google Sheets, and more.
 - For data queries, users typically use the query agent with attached datasources.
 - Never include the raw SQL query in your reply. The user sees results and charts in the UI; your message should only summarize insights or answer the question in 1–3 sentences.
-- Do not use section headers like "Query used (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary.
+- Do not use section headers like "Used query (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary.
 
 # Proactiveness
 - Be proactive only when the user asks you to do something.

--- a/packages/agent-factory-sdk/src/agents/prompts/generic.prompt.ts
+++ b/packages/agent-factory-sdk/src/agents/prompts/generic.prompt.ts
@@ -20,7 +20,7 @@ If the user needs help or wants to report an issue: https://github.com/Guepard-C
 - Qwery works with multiple datasources: PostgreSQL, DuckDB, Google Sheets, and more
 - For data queries, users typically use the query agent with attached datasources
 - Never include the raw SQL query in your reply. The user sees results and charts in the UI; your message should only summarize insights or answer the question in 1–3 sentences
-- Do not use section headers like "Query used (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary
+- Do not use section headers like "Used query (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary
 
 # Proactiveness
 - Be proactive only when the user asks you to do something

--- a/packages/agent-factory-sdk/src/agents/prompts/openai-codex.prompt.ts
+++ b/packages/agent-factory-sdk/src/agents/prompts/openai-codex.prompt.ts
@@ -24,7 +24,7 @@ If the user needs help or wants to report an issue: https://github.com/Guepard-C
 - Qwery works with multiple datasources: PostgreSQL, DuckDB, Google Sheets, and more
 - For data queries, users typically use the query agent with attached datasources
 - Never include the raw SQL query in your reply. The user sees results and charts in the UI; your message should only summarize insights or answer the question in 1–3 sentences
-- Do not use section headers like "Query used (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary
+- Do not use section headers like "Used query (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary
 
 # Proactiveness
 - Be proactive only when the user asks you to do something

--- a/packages/agent-factory-sdk/src/agents/prompts/openai.prompt.ts
+++ b/packages/agent-factory-sdk/src/agents/prompts/openai.prompt.ts
@@ -24,7 +24,7 @@ If the user needs help or wants to report an issue: https://github.com/Guepard-C
 - Qwery works with multiple datasources: PostgreSQL, DuckDB, Google Sheets, and more
 - For data queries, users typically use the query agent with attached datasources
 - Never include the raw SQL query in your reply. The user sees results and charts in the UI; your message should only summarize insights or answer the question in 1–3 sentences
-- Do not use section headers like "Query used (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary
+- Do not use section headers like "Used query (SQL)" or "Key metrics" that expose implementation detail; give a direct, synthetic summary
 
 # Proactiveness
 - Be proactive only when the user asks you to do something


### PR DESCRIPTION
## Related Issue
N/A

## What
Standardizes English wording in agent prompt templates by replacing leftover French examples.
This keeps provider-specific prompts and final-answer guidance consistent.

## How
- `packages/agent-factory-sdk/src/agents/prompts/generic.prompt.ts`
  - Replaces French example headers with English equivalents.
  - Uses `Used query (SQL)` wording.
- `packages/agent-factory-sdk/src/agents/prompts/openai.prompt.ts`
  - Replaces French example headers with English equivalents.
  - Uses `Used query (SQL)` wording.
- `packages/agent-factory-sdk/src/agents/prompts/openai-codex.prompt.ts`
  - Replaces French example headers with English equivalents.
  - Uses `Used query (SQL)` wording.
- `packages/agent-factory-sdk/src/agents/prompts/gemini.prompt.ts`
  - Replaces French example headers with English equivalents.
  - Uses `Used query (SQL)` wording.
- `packages/agent-factory-sdk/src/agents/prompts/anthropic.prompt.ts`
  - Replaces French example headers with English equivalents.
  - Uses `Used query (SQL)` wording.
- `packages/agent-factory-sdk/src/agents/prompts/final-answer.prompt.ts`
  - Removes French starter phrase from anti-pattern guidance.
  - Translates bad/good examples to English and keeps constraints intact.
  - Uses `Used query (SQL)` wording.

## Review Guide
1. Validate shared prompt wording in `packages/agent-factory-sdk/src/agents/prompts/generic.prompt.ts`.
2. Compare provider prompt variants for consistency:
   - `packages/agent-factory-sdk/src/agents/prompts/openai.prompt.ts`
   - `packages/agent-factory-sdk/src/agents/prompts/openai-codex.prompt.ts`
   - `packages/agent-factory-sdk/src/agents/prompts/gemini.prompt.ts`
   - `packages/agent-factory-sdk/src/agents/prompts/anthropic.prompt.ts`
3. Confirm translated examples and final guidance in `packages/agent-factory-sdk/src/agents/prompts/final-answer.prompt.ts`.

## Testing
- [x] Manual verification performed (prompt text reviewed across all updated files)
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- [ ] Targeted type checks run

## Documentation
- [ ] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)

## User Impact
- Prompt instructions are fully English in the updated templates.
- Guidance examples are consistent across model providers.
- No runtime behavior changes; this is prompt-text cleanup only.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests pass locally (`pnpm test`)
- [ ] Lint passes (`pnpm lint:fix`)
- [ ] Type check passes (`pnpm typecheck`)
- [x] This PR can be safely reverted if needed