### PR TITLE
chore(agent-factory-sdk): update GLM 5 to GLM 5.1

### DIFF
--- a/packages/agent-factory-sdk/models.json
+++ b/packages/agent-factory-sdk/models.json
@@ -3526,15 +3526,15 @@
           "output": 64000
         }
       },
-      "glm-5": {
-        "id": "glm-5",
-        "name": "glm-5",
+      "glm-5.1": {
+        "id": "glm-5.1",
+        "name": "glm-5.1",
         "family": "glm",
         "attachment": false,
         "reasoning": true,
         "tool_call": true,
-        "release_date": "2026-02-11",
-        "last_updated": "2026-02-11",
+        "release_date": "2026-03-27",
+        "last_updated": "2026-04-07",
         "open_weights": true,
         "interleaved": {
           "field": "reasoning_content"

--- a/packages/agent-factory-sdk/models.json
+++ b/packages/agent-factory-sdk/models.json
@@ -3526,6 +3526,31 @@
           "output": 64000
         }
       },
+      "gemma4:31b": {
+        "id": "gemma4:31b",
+        "name": "gemma4:31b",
+        "family": "gemma",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-08",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 8192
+        }
+      },
       "glm-5.1": {
         "id": "glm-5.1",
         "name": "glm-5.1",

--- a/packages/agent-factory-sdk/models.json
+++ b/packages/agent-factory-sdk/models.json
@@ -3526,31 +3526,6 @@
           "output": 64000
         }
       },
-      "gemma4:31b": {
-        "id": "gemma4:31b",
-        "name": "gemma4:31b",
-        "family": "gemma",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "knowledge": "2025-01",
-        "release_date": "2026-04-02",
-        "last_updated": "2026-04-08",
-        "modalities": {
-          "input": [
-            "text",
-            "image"
-          ],
-          "output": [
-            "text"
-          ]
-        },
-        "open_weights": true,
-        "limit": {
-          "context": 262144,
-          "output": 8192
-        }
-      },
       "glm-5.1": {
         "id": "glm-5.1",
         "name": "glm-5.1",

--- a/packages/agent-factory-sdk/src/index.ts
+++ b/packages/agent-factory-sdk/src/index.ts
@@ -59,11 +59,6 @@ const baseModels = [
     value: 'ollama-cloud/gemini-3-pro-preview',
   },
   {
-    name: 'Ollama Cloud • Gemma 4 31B',
-    shortName: 'Gemma 4 31B',
-    value: 'ollama-cloud/gemma4:31b',
-  },
-  {
     name: 'Ollama Cloud • GLM 5.1',
     shortName: 'GLM 5.1',
     value: 'ollama-cloud/glm-5.1',

--- a/packages/agent-factory-sdk/src/index.ts
+++ b/packages/agent-factory-sdk/src/index.ts
@@ -59,6 +59,11 @@ const baseModels = [
     value: 'ollama-cloud/gemini-3-pro-preview',
   },
   {
+    name: 'Ollama Cloud • Gemma 4 31B',
+    shortName: 'Gemma 4 31B',
+    value: 'ollama-cloud/gemma4:31b',
+  },
+  {
     name: 'Ollama Cloud • GLM 5.1',
     shortName: 'GLM 5.1',
     value: 'ollama-cloud/glm-5.1',

--- a/packages/agent-factory-sdk/src/index.ts
+++ b/packages/agent-factory-sdk/src/index.ts
@@ -59,9 +59,9 @@ const baseModels = [
     value: 'ollama-cloud/gemini-3-pro-preview',
   },
   {
-    name: 'Ollama Cloud • GLM 5',
-    shortName: 'GLM 5',
-    value: 'ollama-cloud/glm-5',
+    name: 'Ollama Cloud • GLM 5.1',
+    shortName: 'GLM 5.1',
+    value: 'ollama-cloud/glm-5.1',
   },
   {
     name: 'Ollama Cloud • GPT OSS 120B',


### PR DESCRIPTION
## Summary
- replace the curated Ollama Cloud GLM entry with `glm-5.1` in the supported model list
- sync the generated `models.json` catalog entry to the `models.dev` metadata for Ollama Cloud `glm-5.1`

## Verification
- pnpm --filter @qwery/agent-factory-sdk typecheck