### PR TITLE
fix(ui): preserve selected model on edited regenerate

### DIFF
--- a/packages/ui/src/qwery/agent-ui.tsx
+++ b/packages/ui/src/qwery/agent-ui.tsx
@@ -407,6 +407,41 @@ function QweryAgentUIContent(props: QweryAgentUIProps) {
     ],
   );
 
+  const regenerateWithDefaults = useCallback(
+    (options?: Parameters<typeof regenerate>[0]) => {
+      const selectedForRequest =
+        getDatasourcesForSend?.() ?? selectedDatasources;
+      const requestDatasources =
+        selectedForRequest && selectedForRequest.length > 0
+          ? selectedForRequest
+          : undefined;
+      const body = (options?.body ?? {}) as Record<string, unknown>;
+
+      return regenerate({
+        ...(options ?? {}),
+        body: {
+          ...body,
+          model: body.model ?? effectiveModel,
+          webSearch: body.webSearch ?? state.webSearch,
+          searchEngine:
+            body.searchEngine ??
+            preferredSearchEngineProp ??
+            preferredSearchEngine,
+          datasources: body.datasources ?? requestDatasources,
+        },
+      });
+    },
+    [
+      effectiveModel,
+      getDatasourcesForSend,
+      preferredSearchEngine,
+      preferredSearchEngineProp,
+      regenerate,
+      selectedDatasources,
+      state.webSearch,
+    ],
+  );
+
   // Play notification sound when agent response completes
   useCompletionSound(status);
 
@@ -756,7 +791,7 @@ function QweryAgentUIContent(props: QweryAgentUIProps) {
     setEditDatasources([]);
     setEditWarningDialog({ open: false, messageId: '', messageText: '' });
 
-    regenerate();
+    regenerateWithDefaults();
     scrollToBottomRef.current?.();
   }, [
     editingMessageId,
@@ -765,7 +800,7 @@ function QweryAgentUIContent(props: QweryAgentUIProps) {
     messages,
     setMessages,
     onMessageUpdate,
-    regenerate,
+    regenerateWithDefaults,
     scrollToBottomRef,
   ]);
 
@@ -863,7 +898,7 @@ function QweryAgentUIContent(props: QweryAgentUIProps) {
     }
 
     setTimeout(() => {
-      regenerate();
+      regenerateWithDefaults();
       scrollToBottomRef.current?.();
     }, 0);
   }, [
@@ -873,7 +908,7 @@ function QweryAgentUIContent(props: QweryAgentUIProps) {
     setMessages,
     onMessageUpdate,
     messages,
-    regenerate,
+    regenerateWithDefaults,
     scrollToBottomRef,
   ]);
 
@@ -928,12 +963,12 @@ function QweryAgentUIContent(props: QweryAgentUIProps) {
     }
 
     setTimeout(() => {
-      regenerate();
+      regenerateWithDefaults();
       scrollToBottomRef.current?.();
     }, 0);
   }, [
     messages,
-    regenerate,
+    regenerateWithDefaults,
     setMessages,
     scrollToBottomRef,
     selectedDatasources,


### PR DESCRIPTION
<!--
Thank you for contributing to Qwery! 

Please follow the PR title conventions:
🎉 New Datasource: [name]
✨ Datasource [name]: add feature
🐛 Datasource [name]: fix bug
📝 Documentation update
🚨 Breaking change

See docs/contribution/pull-request-guide.md for details.
-->

## Related Issue
#195 

## What
Fixed model persistence for edited reruns in chat.
Edited prompt reruns now use the same request defaults as normal sends, including the selected model.
Prevents unintended fallback to Azure when rerunning an edited message.

## How
Added regenerateWithDefaults in agent-ui.tsx: to inject:
 model
 webSearch
 searchEngine
 datasources
Replaced plain regenerate calls with regenerateWithDefaults in:
agent-ui.tsx


## Review Guide
Verify default injection logic in agentui.tsx
Reproduce manually:
1.Select non-Azure model
2.Send message
3.Edit message and rerun
4.Confirm rerun stays on selected model

## Testing
Ran: pnpm --filter @qwery/ui typecheck (pass)
Not run in this PR flow:
pnpm test
pnpm lint:fix
pnpm typecheck (workspace-wide)

## Documentation
<!--
- [ ] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)
-->

## User Impact
Users who edit and rerun prompts will keep their selected model consistently.
Avoids unexpected Azure fallback errors in environments without Azure credentials.
## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Tests pass locally (`pnpm test`)
- [ ] Lint passes (`pnpm lint:fix`)
- [ ] Type check passes (`pnpm typecheck`)
- [x] This PR can be safely reverted if needed