### PR TITLE
chore: add latest ollama cloud models

### DIFF
--- a/packages/agent-factory-sdk/models.json
+++ b/packages/agent-factory-sdk/models.json
@@ -3526,6 +3526,31 @@
           "output": 65536
         }
       },
+      "gemma4:31b": {
+        "id": "gemma4:31b",
+        "name": "gemma4:31b",
+        "family": "gemma",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "knowledge": "2025-01",
+        "release_date": "2026-04-02",
+        "last_updated": "2026-04-08",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 8192
+        }
+      },
       "gemini-3-pro-preview": {
         "id": "gemini-3-pro-preview",
         "name": "gemini-3-pro-preview",
@@ -3576,6 +3601,32 @@
           "output": 131072
         }
       },
+      "glm-5.1": {
+        "id": "glm-5.1",
+        "name": "glm-5.1",
+        "family": "glm",
+        "attachment": false,
+        "reasoning": true,
+        "tool_call": true,
+        "interleaved": {
+          "field": "reasoning_content"
+        },
+        "release_date": "2026-03-27",
+        "last_updated": "2026-04-07",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 202752,
+          "output": 131072
+        }
+      },
       "gpt-oss:120b": {
         "id": "gpt-oss:120b",
         "name": "gpt-oss:120b",
@@ -3608,6 +3659,30 @@
         "tool_call": true,
         "release_date": "2026-01-27",
         "last_updated": "2026-01-27",
+        "modalities": {
+          "input": [
+            "text",
+            "image"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 262144
+        }
+      },
+      "kimi-k2.6:cloud": {
+        "id": "kimi-k2.6:cloud",
+        "name": "kimi-k2.6:cloud",
+        "family": "kimi",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "release_date": "2026-04-20",
+        "last_updated": "2026-04-20",
         "modalities": {
           "input": [
             "text",
@@ -3742,6 +3817,29 @@
         "limit": {
           "context": 262144,
           "output": 81920
+        }
+      },
+      "qwen3-coder-next": {
+        "id": "qwen3-coder-next",
+        "name": "qwen3-coder-next",
+        "family": "qwen",
+        "attachment": false,
+        "reasoning": false,
+        "tool_call": true,
+        "release_date": "2026-02-02",
+        "last_updated": "2026-02-08",
+        "modalities": {
+          "input": [
+            "text"
+          ],
+          "output": [
+            "text"
+          ]
+        },
+        "open_weights": true,
+        "limit": {
+          "context": 262144,
+          "output": 65536
         }
       }
     }

--- a/packages/agent-factory-sdk/src/index.ts
+++ b/packages/agent-factory-sdk/src/index.ts
@@ -59,9 +59,19 @@ const baseModels = [
     value: 'ollama-cloud/gemma4:31b-cloud',
   },
   {
+    name: 'Ollama Cloud • Gemma 4 31B',
+    shortName: 'Gemma 4 31B',
+    value: 'ollama-cloud/gemma4:31b',
+  },
+  {
     name: 'Ollama Cloud • GLM 5',
     shortName: 'GLM 5',
     value: 'ollama-cloud/glm-5',
+  },
+  {
+    name: 'Ollama Cloud • GLM 5.1',
+    shortName: 'GLM 5.1',
+    value: 'ollama-cloud/glm-5.1',
   },
   {
     name: 'Ollama Cloud • GPT OSS 120B',
@@ -72,6 +82,11 @@ const baseModels = [
     name: 'Ollama Cloud • Kimi K2.5',
     shortName: 'Kimi K2.5',
     value: 'ollama-cloud/kimi-k2.5',
+  },
+  {
+    name: 'Ollama Cloud • Kimi K2.6 Cloud',
+    shortName: 'Kimi K2.6',
+    value: 'ollama-cloud/kimi-k2.6:cloud',
   },
   {
     name: 'Ollama Cloud • MiniMax M2.7',
@@ -92,6 +107,11 @@ const baseModels = [
     name: 'Ollama Cloud • Qwen 3.5 397B',
     shortName: 'Qwen 3.5 397B',
     value: 'ollama-cloud/qwen3.5:397b',
+  },
+  {
+    name: 'Ollama Cloud • Qwen 3 Coder Next',
+    shortName: 'Qwen 3 Coder Next',
+    value: 'ollama-cloud/qwen3-coder-next',
   },
   {
     name: 'WebLLM • Llama 3.1 8B',


### PR DESCRIPTION
## Related Issue

N/A

## What

Add the newest Ollama Cloud models that are still missing from `qwery-core` so they can be selected from the supported model list and resolved through the local model catalog.

## How

Updated `packages/agent-factory-sdk/models.json` with the latest `models.dev` metadata for `gemma4:31b`, `glm-5.1`, `kimi-k2.6:cloud`, and `qwen3-coder-next`.
Updated `packages/agent-factory-sdk/src/index.ts` so those models appear in `SUPPORTED_MODELS`.

## Review Guide

1. Start with `packages/agent-factory-sdk/models.json` for the added Ollama Cloud catalog entries.
2. Review `packages/agent-factory-sdk/src/index.ts` for the supported-model list updates.

## Testing

- [ ] Manual testing performed
- [ ] Unit tests added/updated
- [ ] E2E tests added/updated
- Ran `pnpm test`
- Ran `pnpm lint:fix`
- Ran `pnpm typecheck`

## Documentation

- [ ] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)

## User Impact

Users can select the latest Ollama Cloud models without waiting for a full catalog refresh. No breaking changes are introduced.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`pnpm test`)
- [x] Lint passes (`pnpm lint:fix`)
- [x] Type check passes (`pnpm typecheck`)
- [x] This PR can be safely reverted if needed