### PR TITLE
fix(e2e): wait for streaming to settle before snapshotting chat-turn

### DIFF
--- a/apps/e2e/src/chat-persist.e2e.test.tsx
+++ b/apps/e2e/src/chat-persist.e2e.test.tsx
@@ -34,7 +34,12 @@ describe('e2e: chat turn persists to a real sqlite DB', () => {
       expect(sessions.length).toBe(1);
 
       // HTML screenshot + text-frame snapshot of the rendered conversation.
-      const frame = await waitForFrame(lastFrame, (f) => f.includes('hi there'), { label: 'chat-turn' });
+      // Wait for the reply AND for streaming to settle — otherwise a slower
+      // runner captures the transient "agent: streaming…" indicator, making the
+      // frame snapshot non-deterministic.
+      const frame = await waitForFrame(lastFrame, (f) => f.includes('hi there') && !f.includes('streaming'), {
+        label: 'chat-turn',
+      });
       const snapshot = captureFrame('chat-turn', frame);
       expect(snapshot).toMatchSnapshot();
     } finally {


### PR DESCRIPTION
## Problem
The `chat-persist` e2e test snapshots the rendered chat frame as soon as the assistant reply (`hi there`) appears. On a slower runner the agent is still streaming at that instant, so the frame captures the transient `agent: streaming…  (Ctrl+C to interrupt)` indicator instead of the settled idle state — a non-deterministic snapshot.

This passed on the PR branch run but failed on the post-merge `main` run (CI exposed by the dependabot merges), failing the *Test & Privacy Invariant* job at the *Tests (coverage)* step.

## Fix
Wait for the reply **and** for streaming to settle (`!f.includes('streaming')`) before capturing the frame, so the snapshot is always the deterministic idle state.

## Verification
- `chat-persist` runs green 3×3 locally (deterministic).
- Behavioural assertions (sqlite rows + session created) unchanged.
- Same fragility class as the `/logs`/`/context` snapshots already addressed in #201; the streaming chat tests (abort/tool/shell) already capture HTML only (no snapshot).