### PR TITLE
fix: point install/updater at Guepard-Corp/qwery-core (not qwery-agent)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Row-level data never leaves your machine and is never sent to the LLM. Queries r
 ### Install (recommended)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/Guepard-Corp/qwery-agent/main/install | bash
+curl -fsSL https://raw.githubusercontent.com/Guepard-Corp/qwery-core/main/install | bash
 ```
 
 This installs `qwery` (and the GFS engine) under `~/.qwery` and adds it to your `PATH`. Then just run:

--- a/apps/cli/src/infra/__tests__/updater.test.ts
+++ b/apps/cli/src/infra/__tests__/updater.test.ts
@@ -67,7 +67,7 @@ describe('createUpdater.checkAndStage', () => {
   const fetchImpl = (async (url: string | URL) => {
     const u = String(url);
     if (u.includes('/releases/latest')) {
-      const tag = u.includes('qwery-agent') ? 'v0.2.0' : 'v0.1.14';
+      const tag = u.includes('qwery-core') ? 'v0.2.0' : 'v0.1.14';
       return new Response(JSON.stringify({ tag_name: tag }), { status: 200 });
     }
     if (u.endsWith('.tar.gz')) return new Response(new Uint8Array([0x1f, 0x8b, 0x00]), { status: 200 });

--- a/apps/cli/src/infra/updater.ts
+++ b/apps/cli/src/infra/updater.ts
@@ -155,7 +155,7 @@ export function createUpdater(deps: UpdaterDeps = {}): Updater {
   const specs: ArtifactSpec[] = [
     {
       app: 'qwery',
-      repo: 'Guepard-Corp/qwery-agent',
+      repo: 'Guepard-Corp/qwery-core',
       current: () => getAppVersion(),
       // Tarball is `<app>-<os>-<arch>/{bin,lib}`; we stage only lib/ (ADR #37).
       layout(extractDir, slotDir) {

--- a/install
+++ b/install
@@ -4,12 +4,12 @@ set -euo pipefail
 # qwery installer — downloads the platform tarball from GitHub Releases and
 # installs it under ~/.qwery (ADR #9, #36). Modeled on the GFS installer.
 #
-#   curl -fsSL https://raw.githubusercontent.com/Guepard-Corp/qwery-agent/main/install | bash
+#   curl -fsSL https://raw.githubusercontent.com/Guepard-Corp/qwery-core/main/install | bash
 #   curl -fsSL .../install | bash -s -- --version 0.1.0
 #   ./install --archive dist-release/qwery-macos-aarch64.tar.gz   # local tarball
 
 APP=qwery
-REPO="Guepard-Corp/qwery-agent"
+REPO="Guepard-Corp/qwery-core"
 
 INSTALL_ROOT="$HOME/.qwery"
 BIN_DIR="$INSTALL_ROOT/bin"


### PR DESCRIPTION
## Problem
The documented one-liner fails:
```
curl -fsSL https://raw.githubusercontent.com/Guepard-Corp/qwery-agent/main/install | bash
```
`Guepard-Corp/qwery-agent` is not a public code repo → **HTTP 404**. The `install` script lives in **qwery-core** (`…/qwery-core/main/install` → 200), and that's where CI, `release.yml` and the `Tag` workflow run — so releases are published here too.

## Fix
Align every release/install reference from `qwery-agent` → `qwery-core`:
- `README.md` — the curl URL
- `install` — header example URL + `REPO=`
- `apps/cli/src/infra/updater.ts` — self-update artifact `repo`
- `apps/cli/src/infra/__tests__/updater.test.ts` — mock keyed on the repo slug

Left untouched: `qwery-agent` as the **product name** (AGENTS.md, prompt text) — that's branding, not a repo URL.

## Notes
- The one-liner works once a release exists on `qwery-core` (the `Tag` workflow now cuts `vX.Y.Z`; main is at v0.2.1).
- updater tests + typecheck green.