### PR TITLE
fix: show the real app version in the TUI header (was hardcoded v0.0.1)

### DIFF
--- a/apps/cli/src/app.tsx
+++ b/apps/cli/src/app.tsx
@@ -46,6 +46,7 @@ import {
   trackUpdateCheck,
 } from './infra/telemetry-actions';
 import type { UpdateOutcome } from './infra/updater';
+import { getAppVersion } from './infra/version';
 import { useServices } from './services';
 import { AgentsOverlay } from './tui/agents-overlay';
 import { ChatView } from './tui/chat-view';
@@ -111,6 +112,8 @@ export function App() {
   } = services;
   const termRows = stdout?.rows ?? 30;
   const termCols = stdout?.columns ?? 80;
+  // Real app version (baked at build, or ~/.qwery/version); 'dev' when unknown.
+  const appVersion = useMemo(() => getAppVersion(), []);
   const [activeTab, setActiveTab] = useState<TabKey>('chat');
   const [entries, setEntries] = useState<ChatEntry[]>([]);
   const [streaming, setStreaming] = useState<string>('');
@@ -1018,7 +1021,9 @@ export function App() {
         <Text color="cyan" bold>
           qwery
         </Text>
-        <Text dimColor> · v0.0.1{gfsVersion ? ` (with GFS v${gfsVersion})` : ''}</Text>
+        <Text
+          dimColor
+        >{` · ${appVersion ? `v${appVersion}` : 'dev'}${gfsVersion ? ` (with GFS v${gfsVersion})` : ''}`}</Text>
       </Box>
       {layoutMode === 'split' ? (
         <Box flexDirection="row" flexGrow={1} overflow="hidden">

--- a/apps/e2e/src/__snapshots__/chat-persist.e2e.test.tsx.snap
+++ b/apps/e2e/src/__snapshots__/chat-persist.e2e.test.tsx.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`e2e: chat turn persists to a real sqlite DB a prompt + mock reply are written to sqlite and a session is created 1`] = `
-" qwery · v0.0.1
+" qwery · v0.0.0-e2e
  Chat                                             │ Results
                                                   │
                                                   │

--- a/apps/e2e/src/__snapshots__/slash-basic.e2e.test.tsx.snap
+++ b/apps/e2e/src/__snapshots__/slash-basic.e2e.test.tsx.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`e2e: Tier 1 slash commands /help → "Slash commands:" 1`] = `
-" qwery · v0.0.1
+" qwery · v0.0.0-e2e
  Chat                                             │ Results
                                                   │
                                                   │
@@ -34,7 +34,7 @@ exports[`e2e: Tier 1 slash commands /help → "Slash commands:" 1`] = `
 `;
 
 exports[`e2e: Tier 1 slash commands /data → "Agent routing pinned to: DataAgent." 1`] = `
-" qwery · v0.0.1
+" qwery · v0.0.0-e2e
  Chat                                             │ Results
                                                   │
                                                   │
@@ -67,7 +67,7 @@ exports[`e2e: Tier 1 slash commands /data → "Agent routing pinned to: DataAgen
 `;
 
 exports[`e2e: Tier 1 slash commands /code → "Agent routing pinned to: CodingAgent." 1`] = `
-" qwery · v0.0.1
+" qwery · v0.0.0-e2e
  Chat                                             │ Results
                                                   │
                                                   │
@@ -100,7 +100,7 @@ exports[`e2e: Tier 1 slash commands /code → "Agent routing pinned to: CodingAg
 `;
 
 exports[`e2e: Tier 1 slash commands /auto → "Agent routing pinned to: auto (heuristic)." 1`] = `
-" qwery · v0.0.1
+" qwery · v0.0.0-e2e
  Chat                                             │ Results
                                                   │
                                                   │

--- a/apps/e2e/src/__snapshots__/slash-state.e2e.test.tsx.snap
+++ b/apps/e2e/src/__snapshots__/slash-state.e2e.test.tsx.snap
@@ -1,7 +1,7 @@
 // Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`e2e: Tier 2 slash commands /layout toggles split → focus (TabBar appears) 1`] = `
-" qwery · v0.0.1
+" qwery · v0.0.0-e2e
  ▸ Chat    Results  Tab: switch · Ctrl+C: quit
  ─────────────────────────────────────────────
 
@@ -34,7 +34,7 @@ exports[`e2e: Tier 2 slash commands /layout toggles split → focus (TabBar appe
 `;
 
 exports[`e2e: Tier 2 slash commands /clear removes prior chat entries 1`] = `
-" qwery · v0.0.1
+" qwery · v0.0.0-e2e
  Chat                                             │ Results
                                                   │
                                                   │

--- a/apps/e2e/src/support/harness.tsx
+++ b/apps/e2e/src/support/harness.tsx
@@ -5,6 +5,10 @@ import { render } from 'ink-testing-library';
 import { type MockServicesOptions, makeMockServices } from './mock-services';
 import { captureFrame } from './screenshot';
 
+// Pin the app version so the rendered header is deterministic in snapshots,
+// regardless of the machine's baked QWERY_VERSION or installed ~/.qwery/version.
+process.env.QWERY_VERSION = '0.0.0-e2e';
+
 const DOWN_ARROW = '\x1B[B';
 
 export const delay = (ms: number) => new Promise((r) => setTimeout(r, ms));


### PR DESCRIPTION
## Problem
The header always rendered `qwery · v0.0.1` — a hardcoded string literal in `app.tsx`, ignoring the actual version. So an installed binary still showed `v0.0.1` regardless of the release it came from.

## Fix
- `app.tsx`: render the version from `getAppVersion()` (baked `QWERY_VERSION` at build, or the installer-written `~/.qwery/version`; `dev` when unknown) instead of the literal.
- `apps/e2e/support/harness.tsx`: pin `QWERY_VERSION=0.0.0-e2e` so the header is deterministic in snapshots regardless of the machine's baked/installed version (otherwise `~/.qwery/version` would leak into snapshots and differ between local and CI).
- Regenerated the 3 header-bearing snapshots (`slash-basic`, `slash-state`, `chat-persist`) → now show `v0.0.0-e2e`.

## Verification
- typecheck + 835 tests green; e2e 23/23.
- Released binary will show its real version (`QWERY_VERSION` is baked via `--define` in `build-release.ts`).