### PR TITLE
feat(agent): make the agent GFS-aware with a read-only gfsStatus tool

### DIFF
--- a/apps/cli/src/app.tsx
+++ b/apps/cli/src/app.tsx
@@ -838,6 +838,7 @@ export function App() {
             registry: {
               datasourceRepo,
               usageRepo,
+              branching,
               getAttachState: (id) => attachedDatasources.get(id),
               attachDatasource: async (id) => {
                 const ds = await datasourceRepo.findById(id);

--- a/packages/agent-factory-sdk/src/__tests__/tool-registry.test.ts
+++ b/packages/agent-factory-sdk/src/__tests__/tool-registry.test.ts
@@ -252,3 +252,69 @@ describe('skill tools', () => {
     expect(ko.error).toMatch(/not found/);
   });
 });
+
+describe('gfsStatus tool', () => {
+  test('not registered without a branching dep', () => {
+    const reg = buildToolRegistry({}, baseCore, makeRegistryContext());
+    expect(reg.deferred.some((t) => t.name === 'gfsStatus')).toBe(false);
+  });
+
+  test('reports status when GFS is available', async () => {
+    const branching = {
+      isAvailable: async () => true,
+      version: async () => '0.1.13',
+      status: async () => ({
+        currentBranch: 'main',
+        head: 'abc123',
+        provider: 'postgres',
+        providerVersion: '16',
+        containerStatus: 'running',
+        containerRunning: true,
+        connectionString: 'postgres://secret@localhost/db',
+      }),
+    } as unknown as Parameters<typeof buildToolRegistry>[0]['branching'];
+
+    const reg = buildToolRegistry({ branching }, baseCore, makeRegistryContext());
+    const gfs = reg.deferred.find((t) => t.name === 'gfsStatus')!;
+    const r = (await exec(gfs.tool as unknown as ToolExecHandle)) as Record<string, unknown>;
+    expect(r.ok).toBe(true);
+    expect(r.available).toBe(true);
+    expect(r.version).toBe('0.1.13');
+    expect(r.currentBranch).toBe('main');
+    // Privacy: the connection string is never surfaced to the LLM.
+    expect(JSON.stringify(r)).not.toContain('secret');
+  });
+
+  test('reports unavailable with an install hint', async () => {
+    const branching = {
+      isAvailable: async () => false,
+      version: async () => undefined,
+      status: async () => {
+        throw new Error('should not be called');
+      },
+    } as unknown as Parameters<typeof buildToolRegistry>[0]['branching'];
+
+    const reg = buildToolRegistry({ branching }, baseCore, makeRegistryContext());
+    const gfs = reg.deferred.find((t) => t.name === 'gfsStatus')!;
+    const r = (await exec(gfs.tool as unknown as ToolExecHandle)) as Record<string, unknown>;
+    expect(r.available).toBe(false);
+    expect(String(r.hint)).toMatch(/install/i);
+  });
+
+  test('handles an initialized-less repo gracefully', async () => {
+    const branching = {
+      isAvailable: async () => true,
+      version: async () => '0.1.13',
+      status: async () => {
+        throw new Error('not a gfs repository');
+      },
+    } as unknown as Parameters<typeof buildToolRegistry>[0]['branching'];
+
+    const reg = buildToolRegistry({ branching }, baseCore, makeRegistryContext());
+    const gfs = reg.deferred.find((t) => t.name === 'gfsStatus')!;
+    const r = (await exec(gfs.tool as unknown as ToolExecHandle)) as Record<string, unknown>;
+    expect(r.ok).toBe(true);
+    expect(r.available).toBe(true);
+    expect(r.initialized).toBe(false);
+  });
+});

--- a/packages/agent-factory-sdk/src/system-prompt.ts
+++ b/packages/agent-factory-sdk/src/system-prompt.ts
@@ -16,6 +16,11 @@ You start each turn with a small base toolset (the ones described below) plus th
 
 Use this when you suspect a capability exists that you don't currently see — list/test/attach/detach datasources, read skills, list usage, etc. Don't try to call a tool that isn't active: it will be rejected. Load first, then call.
 
+GFS — VERSIONED DATABASE SANDBOX
+GFS ("Guepard File System") is qwery's built-in **git-for-data**: version control for databases (branches, commits, time-travel, schema diff) backed by a local Postgres/MySQL container. It is qwery's safety layer — NOT Google File System, Firebase, GCS, or any cloud product. When the user mentions "GFS", "branch the data", "commit/snapshot the database", "sandbox", or "sync this database into GFS", they mean this. Never guess GFS is something external, and never propose pg_dump/Debezium/ETL as a substitute for GFS itself.
+- GFS workflow tools are deferred: discover them with \`searchTools("gfs")\` and activate via \`loadTool\`. \`gfsStatus\` reports whether GFS is installed, its version, the current branch/HEAD, and the container state — load and call it before answering GFS questions or starting a versioning workflow.
+- If \`gfsStatus\` reports GFS is not installed, tell the user to install it (gfs.guepard.run/install).
+
 SYSTEM TOOLS — for code/config/scripts only, NEVER for data files
 - **bash(command)** — runs a shell command in the workspace (cwd pinned), killed after 30s, output capped at 64KB. Use for git, ls, build commands, ad-hoc orchestration. Do NOT cat data files (csv/parquet/json/sqlite) — that bypasses the privacy boundary.
 - **read(path)** — reads a UTF-8 file from the workspace (up to 64KB). Use for scripts, configs, READMEs, schema definitions. Do NOT read data files — use schema/runQuery/present instead.

--- a/packages/agent-factory-sdk/src/tool-registry.ts
+++ b/packages/agent-factory-sdk/src/tool-registry.ts
@@ -1,4 +1,4 @@
-import type { IDatasourceRepository, IUsageRepository } from '@qwery/domain';
+import type { Branching, IDatasourceRepository, IUsageRepository } from '@qwery/domain';
 import { type Tool, tool } from 'ai';
 import { z } from 'zod';
 
@@ -62,6 +62,8 @@ export interface ToolRegistryDeps {
   readSkill?: (name: string) => Promise<{ name: string; content: string; path: string } | null>;
   /** Usage repository (read-only listing). */
   usageRepo?: IUsageRepository;
+  /** GFS version-control port; enables the read-only `gfsStatus` tool. */
+  branching?: Branching;
 }
 
 interface RegistryContext {
@@ -261,6 +263,55 @@ export function buildToolRegistry(
               timestamp: u.timestamp,
             })),
           };
+        },
+      }),
+    });
+  }
+
+  // -------- GFS (versioned database sandbox) --------
+  if (deps.branching) {
+    deferred.push({
+      name: 'gfsStatus',
+      scope: 'all',
+      description:
+        "Report the status of GFS (Guepard File System — qwery's git-for-data version-control sandbox): whether it is installed, its version, the current branch, HEAD commit, the database provider, and whether the database container is running. Use this to answer any question about GFS or before a versioning workflow. Read-only; reveals no row data or credentials.",
+      tool: tool({
+        description: 'Report GFS (versioned database sandbox) availability and status.',
+        inputSchema: z.object({}),
+        execute: async () => {
+          const available = await deps.branching!.isAvailable();
+          if (!available) {
+            return {
+              ok: true as const,
+              available: false as const,
+              hint: 'GFS is not installed. Install it from gfs.guepard.run/install to enable the versioned database sandbox.',
+            };
+          }
+          const version = await deps.branching!.version();
+          try {
+            const status = await deps.branching!.status();
+            return {
+              ok: true as const,
+              available: true as const,
+              version,
+              currentBranch: status.currentBranch,
+              head: status.head,
+              provider: status.provider,
+              providerVersion: status.providerVersion,
+              containerStatus: status.containerStatus,
+              containerRunning: status.containerRunning,
+            };
+          } catch (err) {
+            // GFS is installed but no repo is initialized in this directory yet.
+            return {
+              ok: true as const,
+              available: true as const,
+              version,
+              initialized: false as const,
+              hint: 'GFS is installed but no repository is initialized in this directory yet.',
+              error: err instanceof Error ? err.message : String(err),
+            };
+          }
         },
       }),
     });


### PR DESCRIPTION
## Problème

Interrogé sur « sync cette base de données dans **GFS** », l'agent **hallucinait** : il proposait « Google File System / GCS / Firebase / Hadoop GFS » et des solutions hors-sujet (pg_dump, Debezium, ETL). Or GFS = **Guepard File System**, le versioning de bases « git-for-data » qui est le bac à sable de sécurité de qwery.

**Cause** : le port `Branching` et l'adapter `branching-gfs` existent, mais GFS n'était **ni dans le system prompt ni exposé comme tool** à l'agent.

## Premier incrément : awareness + status (fondation)

- **System prompt** : nouveau bloc « GFS — versioned database sandbox » expliquant ce qu'est GFS (git-for-data : branches, commits, time-travel, conteneur Postgres/MySQL local), et que ce **n'est pas** un produit cloud. L'agent ne doit plus deviner ni proposer pg_dump/Debezium en substitut de GFS.
- **Tool `gfsStatus`** (deferred, activable via `loadTool`) : gardé par une nouvelle dep optionnelle `branching` du registry. Renvoie disponibilité, version, branche/HEAD courants, provider, état du conteneur. **Read-only**, **aucune donnée ligne ni connection string** (privacy, ADR #28). Dégrade proprement si GFS absent (hint d'installation) ou si aucun repo n'est initialisé.
- **Wiring** : `app.tsx` passe le service `branching` existant dans les deps du registry.

## Hors scope (incréments suivants, déjà cadrés)

`materialize`/`ingest` (la vraie capacité « sync dans GFS »), puis le filet de sécurité destructif (`guardedWrite` branché dans runQuery/present).

## Vérifications

- **847 tests** (4 nouveaux pour `gfsStatus` : registration, available, unavailable, repo non initialisé, + assertion anti-fuite du connection string)
- `tsc -b`, `bun run lint` (exit 0), `check:arch` (dep-cruiser) — verts

🤖 Generated with [Claude Code](https://claude.com/claude-code)