### PR TITLE
fix(security): protect qwery secrets — sandbox bash + benign allowlist + master key in OS keyring

### DIFF
--- a/apps/cli/src/infra/__tests__/secret-vault.test.ts
+++ b/apps/cli/src/infra/__tests__/secret-vault.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
+import { randomBytes } from 'node:crypto';
+import { existsSync, promises as fs, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { createSecretVault, type MasterKeyring } from '../secret-vault';
+
+const KEY_BYTES = 32;
+
+/** In-memory keyring for deterministic tests (no OS calls). */
+class MemKeyring implements MasterKeyring {
+  store: Buffer | null = null;
+  async get() {
+    return this.store;
+  }
+  async set(key: Buffer) {
+    this.store = Buffer.from(key);
+  }
+}
+
+/** A keyring whose writes always fail (e.g. headless Linux, no D-Bus). */
+const failingKeyring: MasterKeyring = {
+  async get() {
+    return null;
+  },
+  async set() {
+    throw new Error('no secret service');
+  },
+};
+
+let dir: string;
+let keyPath: string;
+
+beforeEach(() => {
+  dir = path.join(tmpdir(), `qwery-vault-${randomBytes(6).toString('hex')}`);
+  mkdirSync(dir, { recursive: true });
+  keyPath = path.join(dir, '.master.key');
+});
+
+afterEach(() => {
+  if (existsSync(dir)) rmSync(dir, { recursive: true, force: true });
+});
+
+describe('SecretVault — crypto round-trip', () => {
+  test('protect then reveal returns the original value (file fallback)', async () => {
+    const vault = createSecretVault({ keyPath, keyring: null });
+    const handle = await vault.protect('hunter2', { keyName: 'pg.password' });
+    expect(vault.isProtected(handle)).toBe(true);
+    expect(await vault.reveal(handle)).toBe('hunter2');
+    // No keyring → key persisted to the file.
+    expect(existsSync(keyPath)).toBe(true);
+  });
+
+  test('round-trips with a keyring and writes no key file', async () => {
+    const keyring = new MemKeyring();
+    const vault = createSecretVault({ keyPath, keyring });
+    const handle = await vault.protect('s3cr3t', { keyName: 'k' });
+    expect(await vault.reveal(handle)).toBe('s3cr3t');
+    expect(keyring.store?.length).toBe(KEY_BYTES);
+    expect(existsSync(keyPath)).toBe(false); // never touched disk
+  });
+});
+
+describe('SecretVault — master key migration', () => {
+  test('imports a legacy file key into the keyring, deletes the file, still decrypts', async () => {
+    // Encrypt with a file-only vault first.
+    const fileVault = createSecretVault({ keyPath, keyring: null });
+    const handle = await fileVault.protect('legacy-secret', { keyName: 'k' });
+    expect(existsSync(keyPath)).toBe(true);
+    const onDisk = await fs.readFile(keyPath);
+
+    // New run with a keyring: migrate.
+    const keyring = new MemKeyring();
+    const migrated = createSecretVault({ keyPath, keyring });
+    expect(await migrated.reveal(handle)).toBe('legacy-secret'); // same key still works
+    expect(keyring.store?.equals(onDisk)).toBe(true); // exact key imported
+    expect(existsSync(keyPath)).toBe(false); // plaintext file removed
+  });
+
+  test('keeps the file when the keyring write fails (never loses the key)', async () => {
+    const fileVault = createSecretVault({ keyPath, keyring: null });
+    const handle = await fileVault.protect('keep-me', { keyName: 'k' });
+
+    const stillFile = createSecretVault({ keyPath, keyring: failingKeyring });
+    expect(await stillFile.reveal(handle)).toBe('keep-me');
+    expect(existsSync(keyPath)).toBe(true); // file preserved on failed migration
+  });
+
+  test('prefers an existing keyring key over a stray file', async () => {
+    const keyring = new MemKeyring();
+    const known = randomBytes(KEY_BYTES);
+    keyring.store = Buffer.from(known);
+    // A stray (different) file key must be ignored.
+    writeFileSync(keyPath, randomBytes(KEY_BYTES));
+
+    const vault = createSecretVault({ keyPath, keyring });
+    const handle = await vault.protect('via-keyring', { keyName: 'k' });
+
+    // A second vault that only has the keyring key must decrypt it.
+    const verifier = createSecretVault({ keyPath: path.join(dir, 'absent.key'), keyring });
+    expect(await verifier.reveal(handle)).toBe('via-keyring');
+  });
+});

--- a/apps/cli/src/infra/__tests__/secret-vault.test.ts
+++ b/apps/cli/src/infra/__tests__/secret-vault.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from 'bun:test';
 import { randomBytes } from 'node:crypto';
-import { existsSync, promises as fs, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { existsSync, promises as fs, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { createSecretVault, type MasterKeyring } from '../secret-vault';
@@ -32,8 +32,8 @@ let dir: string;
 let keyPath: string;
 
 beforeEach(() => {
-  dir = path.join(tmpdir(), `qwery-vault-${randomBytes(6).toString('hex')}`);
-  mkdirSync(dir, { recursive: true });
+  // mkdtempSync creates a unique 0700 dir atomically — no predictable temp path.
+  dir = mkdtempSync(path.join(tmpdir(), 'qwery-vault-'));
   keyPath = path.join(dir, '.master.key');
 });
 

--- a/apps/cli/src/infra/secret-vault.ts
+++ b/apps/cli/src/infra/secret-vault.ts
@@ -1,5 +1,6 @@
+import { spawn } from 'node:child_process';
 import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
-import { promises as fs } from 'node:fs';
+import { existsSync, promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import type { ISecretVault } from '@qwery/domain';
@@ -9,18 +10,185 @@ const ALGO = 'aes-256-gcm';
 const IV_BYTES = 12;
 const KEY_BYTES = 32;
 
+const KEYRING_SERVICE = 'qwery';
+const KEYRING_ACCOUNT = 'master-key';
+const KEYRING_TIMEOUT_MS = 5_000;
+
 /**
- * File-backed secret vault — encrypts values with AES-256-GCM under a master
- * key stored at `~/.qwery/.master.key` (auto-generated, 0600). ADR #19 calls
- * for OS Keychain first with this encrypted-file as a fallback; for MVP we
- * ship the fallback path only and upgrade to keyring later without changing
- * the port contract. Lives in the CLI composition root (ADR #35) and is
- * injected into the persistence adapter so adapters stay decoupled.
+ * Stores the 32-byte AES master key out of reach of the `bash` tool. Backed by
+ * the OS keyring (macOS `security`, Linux `secret-tool`) so the key is never a
+ * plaintext file on disk — the encrypted-file path remains only as a fallback
+ * where no keyring is reachable (ADR #19).
  */
-export class FileSecretVault implements ISecretVault {
+export interface MasterKeyring {
+  get(): Promise<Buffer | null>;
+  set(key: Buffer): Promise<void>;
+}
+
+/** Spawn a keyring CLI with a timeout so a prompt or hang never freezes the app. */
+function runCmd(bin: string, args: string[], stdin?: Buffer): Promise<{ code: number; stdout: string }> {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn(bin, args);
+    let out = '';
+    let settled = false;
+    const timer = setTimeout(() => {
+      settled = true;
+      child.kill('SIGKILL');
+      reject(new Error(`${bin} timed out`));
+    }, KEYRING_TIMEOUT_MS);
+    child.stdout.on('data', (c: Buffer) => {
+      out += c.toString('utf-8');
+    });
+    child.on('error', (err) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      reject(err);
+    });
+    child.on('close', (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolvePromise({ code: code ?? 0, stdout: out });
+    });
+    if (stdin !== undefined) child.stdin.write(stdin);
+    child.stdin.end();
+  });
+}
+
+/** macOS login keychain via the `security` CLI. */
+class MacSecurityKeyring implements MasterKeyring {
+  async get(): Promise<Buffer | null> {
+    try {
+      const { code, stdout } = await runCmd('security', [
+        'find-generic-password',
+        '-a',
+        KEYRING_ACCOUNT,
+        '-s',
+        KEYRING_SERVICE,
+        '-w',
+      ]);
+      if (code !== 0) return null;
+      const key = Buffer.from(stdout.trim(), 'base64');
+      return key.length === KEY_BYTES ? key : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async set(key: Buffer): Promise<void> {
+    // `-w <value>` passes the key as argv (brief `ps` visibility); acceptable
+    // vs. a persistent plaintext file. `security` has no stdin password input.
+    const { code } = await runCmd('security', [
+      'add-generic-password',
+      '-U',
+      '-a',
+      KEYRING_ACCOUNT,
+      '-s',
+      KEYRING_SERVICE,
+      '-w',
+      key.toString('base64'),
+    ]);
+    if (code !== 0) throw new Error('security add-generic-password failed');
+  }
+}
+
+/** Linux secret service (libsecret) via the `secret-tool` CLI. */
+class SecretToolKeyring implements MasterKeyring {
+  async get(): Promise<Buffer | null> {
+    try {
+      const { code, stdout } = await runCmd('secret-tool', [
+        'lookup',
+        'service',
+        KEYRING_SERVICE,
+        'account',
+        KEYRING_ACCOUNT,
+      ]);
+      if (code !== 0) return null;
+      const key = Buffer.from(stdout.trim(), 'base64');
+      return key.length === KEY_BYTES ? key : null;
+    } catch {
+      return null;
+    }
+  }
+
+  async set(key: Buffer): Promise<void> {
+    // secret-tool reads the secret from stdin — no argv exposure.
+    const { code } = await runCmd(
+      'secret-tool',
+      ['store', '--label=qwery master key', 'service', KEYRING_SERVICE, 'account', KEYRING_ACCOUNT],
+      Buffer.from(key.toString('base64')),
+    );
+    if (code !== 0) throw new Error('secret-tool store failed');
+  }
+}
+
+/** The platform keyring, or null where none applies (real usability is verified at write time). */
+export function detectKeyring(): MasterKeyring | null {
+  if (process.platform === 'darwin' && existsSync('/usr/bin/security')) return new MacSecurityKeyring();
+  if (process.platform === 'linux') return new SecretToolKeyring();
+  return null;
+}
+
+async function saveAndVerify(keyring: MasterKeyring, key: Buffer): Promise<boolean> {
+  try {
+    await keyring.set(key);
+    const back = await keyring.get();
+    return back !== null && back.equals(key);
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Resolve the master key with a safe migration path:
+ *   1. keyring already holds it → use it;
+ *   2. legacy `~/.qwery/.master.key` present → if the keyring write+readback
+ *      succeeds, import the SAME key (existing ciphertext still decrypts) then
+ *      delete the file; otherwise keep using the file;
+ *   3. nothing yet → generate one, store it in the keyring (verified) or, failing
+ *      that, fall back to a 0600 file.
+ * The file is only removed once the key is provably in the keyring, so a key is
+ * never lost.
+ */
+async function resolveMasterKey(keyring: MasterKeyring | null, keyPath: string): Promise<Buffer> {
+  if (keyring) {
+    const existing = await keyring.get();
+    if (existing) return existing;
+  }
+
+  let fileKey: Buffer | null = null;
+  try {
+    const raw = await fs.readFile(keyPath);
+    if (raw.length !== KEY_BYTES) throw new Error(`master key at ${keyPath} has unexpected length`);
+    fileKey = raw;
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+  }
+
+  if (fileKey) {
+    if (keyring && (await saveAndVerify(keyring, fileKey))) {
+      await fs.rm(keyPath, { force: true });
+    }
+    return fileKey;
+  }
+
+  const key = randomBytes(KEY_BYTES);
+  if (keyring && (await saveAndVerify(keyring, key))) return key;
+  await fs.mkdir(path.dirname(keyPath), { recursive: true });
+  await fs.writeFile(keyPath, key, { mode: 0o600 });
+  return key;
+}
+
+/**
+ * AES-256-GCM secret vault. Lives in the CLI composition root (ADR #35) and is
+ * injected into the persistence adapter so adapters stay decoupled. The key is
+ * resolved lazily on first use via the injected resolver.
+ */
+export class SecretVault implements ISecretVault {
   private keyPromise: Promise<Buffer> | null = null;
 
-  constructor(private readonly keyPath: string) {}
+  constructor(private readonly resolveKey: () => Promise<Buffer>) {}
 
   async protect(value: string, _context: { keyName: string; datasourceId?: string }): Promise<string> {
     const key = await this.getKey();
@@ -36,7 +204,7 @@ export class FileSecretVault implements ISecretVault {
     const body = protectedValue.slice(PREFIX.length);
     const [ivPart, ctPart, tagPart] = body.split(':');
     if (!ivPart || !ctPart || !tagPart) {
-      throw new Error('FileSecretVault.reveal: malformed handle');
+      throw new Error('SecretVault.reveal: malformed handle');
     }
     const key = await this.getKey();
     const iv = Buffer.from(ivPart, 'base64url');
@@ -52,27 +220,9 @@ export class FileSecretVault implements ISecretVault {
     return typeof value === 'string' && value.startsWith(PREFIX);
   }
 
-  private async getKey(): Promise<Buffer> {
-    if (this.keyPromise === null) {
-      this.keyPromise = this.loadOrCreateKey();
-    }
+  private getKey(): Promise<Buffer> {
+    if (this.keyPromise === null) this.keyPromise = this.resolveKey();
     return this.keyPromise;
-  }
-
-  private async loadOrCreateKey(): Promise<Buffer> {
-    try {
-      const raw = await fs.readFile(this.keyPath);
-      if (raw.length !== KEY_BYTES) {
-        throw new Error(`FileSecretVault: master key at ${this.keyPath} has unexpected length`);
-      }
-      return raw;
-    } catch (err) {
-      if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
-      await fs.mkdir(path.dirname(this.keyPath), { recursive: true });
-      const key = randomBytes(KEY_BYTES);
-      await fs.writeFile(this.keyPath, key, { mode: 0o600 });
-      return key;
-    }
   }
 }
 
@@ -80,6 +230,14 @@ export function defaultMasterKeyPath(): string {
   return process.env.QWERY_MASTER_KEY_PATH ?? path.join(homedir(), '.qwery', '.master.key');
 }
 
-export function createFileSecretVault(keyPath = defaultMasterKeyPath()): FileSecretVault {
-  return new FileSecretVault(keyPath);
+export interface CreateSecretVaultOptions {
+  keyPath?: string;
+  /** Injected keyring. `undefined` = auto-detect the platform keyring; `null` = force the file fallback. */
+  keyring?: MasterKeyring | null;
+}
+
+export function createSecretVault(opts: CreateSecretVaultOptions = {}): SecretVault {
+  const keyPath = opts.keyPath ?? defaultMasterKeyPath();
+  const keyring = opts.keyring === undefined ? detectKeyring() : opts.keyring;
+  return new SecretVault(() => resolveMasterKey(keyring, keyPath));
 }

--- a/apps/cli/src/main.tsx
+++ b/apps/cli/src/main.tsx
@@ -24,7 +24,7 @@ import { App } from './app';
 import { createFileConfigStore } from './infra/config';
 import { createAttachedDatasourcesRegistry } from './infra/datasources';
 import { createFileLogger } from './infra/logger';
-import { createFileSecretVault } from './infra/secret-vault';
+import { createSecretVault } from './infra/secret-vault';
 import { getAnonymousId } from './infra/telemetry';
 import { createUpdater } from './infra/updater';
 import { type AppServices, ServicesProvider } from './services';
@@ -36,8 +36,9 @@ const logger = createFileLogger();
 // QWERY_TELEMETRY_ENABLED=false. The rest of the app only sees `services.telemetry`.
 const telemetry = createTelemetry({ serviceName: 'qwery-cli', distinctId: getAnonymousId() });
 // The vault is built here (composition root) and injected into the persistence
-// adapter so the adapter depends on no other adapter (ADR #35).
-const vault = createFileSecretVault();
+// adapter so the adapter depends on no other adapter (ADR #35). The master key
+// lives in the OS keyring (file fallback), migrating any legacy on-disk key.
+const vault = createSecretVault();
 const persistence = createSqlitePersistence({ vault });
 const compute = createDuckDBCompute();
 const branching = createGfsBranching();

--- a/packages/agent-factory-sdk/src/__tests__/system-tools.test.ts
+++ b/packages/agent-factory-sdk/src/__tests__/system-tools.test.ts
@@ -37,6 +37,19 @@ describe('resolveSafePath', () => {
     expect(p).toContain('.qwery/cache');
   });
 
+  test('accepts user-level skills and agents under ~/.qwery', () => {
+    const skill = resolveSafePath(path.join(homedir(), '.qwery', 'skills', 'use-gfs-cli', 'SKILL.md'));
+    expect(skill).toContain('.qwery/skills');
+    const agent = resolveSafePath(path.join(homedir(), '.qwery', 'agents', 'foo.md'));
+    expect(agent).toContain('.qwery/agents');
+  });
+
+  test('refuses qwery secrets (master key, db, config)', () => {
+    expect(() => resolveSafePath(path.join(homedir(), '.qwery', '.master.key'))).toThrow(/outside|Allowed/);
+    expect(() => resolveSafePath(path.join(homedir(), '.qwery', 'qwery.sqlite'))).toThrow(/outside|Allowed/);
+    expect(() => resolveSafePath(path.join(homedir(), '.qwery', 'config.json'))).toThrow(/outside|Allowed/);
+  });
+
   test('refuses /etc/passwd', () => {
     expect(() => resolveSafePath('/etc/passwd')).toThrow(/outside/);
   });
@@ -135,7 +148,7 @@ describe('runBash', () => {
 
   test('rejects a command that reads qwery secrets before spawning', async () => {
     await expect(runBash('sqlite3 ~/.qwery/qwery.sqlite "SELECT config FROM datasources"')).rejects.toThrow(
-      /private directory/,
+      /blocked/,
     );
   });
 });
@@ -148,10 +161,16 @@ describe('assertBashCommandAllowed — ~/.qwery guard', () => {
     `cat ${path.join(homedir(), '.qwery', 'config.json')}`,
     'find ~/.qwery -name "*.json"',
     'cp /tmp/x ~/.qwery/.master.key',
+    // "agent" dirs that are nonetheless sensitive — must stay blocked.
+    'cat ~/.qwery/mcp.json',
+    'cat ~/.qwery/settings.json',
+    'cat ~/.qwery/sessions/last.json',
+    'cat ~/.qwery/storage/artifact/result.json',
+    'cat ~/.qwery/memory/notes.md',
   ];
   for (const cmd of blocked) {
     test(`blocks: ${cmd.slice(0, 40)}`, () => {
-      expect(() => assertBashCommandAllowed(cmd)).toThrow(/private directory/);
+      expect(() => assertBashCommandAllowed(cmd)).toThrow(/blocked/);
     });
   }
 
@@ -159,7 +178,14 @@ describe('assertBashCommandAllowed — ~/.qwery guard', () => {
     'ls -la',
     'git status',
     'bun test',
-    'cat ~/.qwery/cache/models.json', // cache subdir is permitted
+    'cat ~/.qwery/cache/models.json', // benign subdirs are permitted
+    'cat ~/.qwery/skills/use-gfs-cli/SKILL.md',
+    'ls ~/.qwery/agents',
+    'tail ~/.qwery/logs/qwery.log',
+    'cat ~/.qwery/commands/foo.md',
+    'cat ~/.qwery/hooks/pre.sh',
+    'cat ~/.qwery/prompts/x.md',
+    'ls ~/.qwery/plugins',
     'echo "no qwery here"',
     'cat package.json',
   ];

--- a/packages/agent-factory-sdk/src/__tests__/system-tools.test.ts
+++ b/packages/agent-factory-sdk/src/__tests__/system-tools.test.ts
@@ -3,6 +3,7 @@ import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
 import {
+  assertBashCommandAllowed,
   BASH_MAX_OUTPUT_BYTES,
   BASH_TIMEOUT_MS,
   READ_MAX_BYTES,
@@ -130,4 +131,40 @@ describe('runBash', () => {
   test('BASH_TIMEOUT_MS is a positive number', () => {
     expect(BASH_TIMEOUT_MS).toBeGreaterThan(0);
   });
+
+  test('rejects a command that reads qwery secrets before spawning', async () => {
+    await expect(runBash('sqlite3 ~/.qwery/qwery.sqlite "SELECT config FROM datasources"')).rejects.toThrow(
+      /private directory/,
+    );
+  });
+});
+
+describe('assertBashCommandAllowed — ~/.qwery guard', () => {
+  const blocked = [
+    'cat ~/.qwery/.master.key',
+    'sqlite3 ~/.qwery/qwery.sqlite "SELECT config FROM datasources"',
+    'cat ~/.qwery/config.json | python3 -c "import sys"',
+    `cat ${path.join(homedir(), '.qwery', 'config.json')}`,
+    'find ~/.qwery -name "*.json"',
+    'cp /tmp/x ~/.qwery/.master.key',
+  ];
+  for (const cmd of blocked) {
+    test(`blocks: ${cmd.slice(0, 40)}`, () => {
+      expect(() => assertBashCommandAllowed(cmd)).toThrow(/private directory/);
+    });
+  }
+
+  const allowed = [
+    'ls -la',
+    'git status',
+    'bun test',
+    'cat ~/.qwery/cache/models.json', // cache subdir is permitted
+    'echo "no qwery here"',
+    'cat package.json',
+  ];
+  for (const cmd of allowed) {
+    test(`allows: ${cmd.slice(0, 40)}`, () => {
+      expect(() => assertBashCommandAllowed(cmd)).not.toThrow();
+    });
+  }
 });

--- a/packages/agent-factory-sdk/src/__tests__/system-tools.test.ts
+++ b/packages/agent-factory-sdk/src/__tests__/system-tools.test.ts
@@ -6,6 +6,7 @@ import {
   assertBashCommandAllowed,
   BASH_MAX_OUTPUT_BYTES,
   BASH_TIMEOUT_MS,
+  bwrapArgs,
   READ_MAX_BYTES,
   readFileSafe,
   resolveSafePath,
@@ -167,4 +168,20 @@ describe('assertBashCommandAllowed — ~/.qwery guard', () => {
       expect(() => assertBashCommandAllowed(cmd)).not.toThrow();
     });
   }
+});
+
+describe('bwrapArgs — Linux sandbox recipe', () => {
+  test('masks ~/.qwery with a tmpfs and isolates the command', () => {
+    const args = bwrapArgs("printf 'x'");
+    const qweryHome = path.join(homedir(), '.qwery');
+    // The qwery private dir is overlaid with an empty tmpfs.
+    const ti = args.indexOf('--tmpfs');
+    expect(ti).toBeGreaterThanOrEqual(0);
+    expect(args[ti + 1]).toBe(qweryHome);
+    // The command runs after the `--` separator, via bash -c.
+    const sep = args.indexOf('--');
+    expect(args.slice(sep)).toEqual(['--', 'bash', '-c', "printf 'x'"]);
+    // Whole filesystem is passed through so legit tooling still works.
+    expect(args.slice(0, 3)).toEqual(['--dev-bind', '/', '/']);
+  });
 });

--- a/packages/agent-factory-sdk/src/system-prompt.ts
+++ b/packages/agent-factory-sdk/src/system-prompt.ts
@@ -17,7 +17,7 @@ You start each turn with a small base toolset (the ones described below) plus th
 Use this when you suspect a capability exists that you don't currently see — list/test/attach/detach datasources, read skills, list usage, etc. Don't try to call a tool that isn't active: it will be rejected. Load first, then call.
 
 SYSTEM TOOLS — for code/config/scripts only, NEVER for data files
-- **bash(command)** — runs a shell command in the workspace (cwd pinned), killed after 30s, output capped at 64KB. Use for git, ls, build commands, ad-hoc orchestration. Do NOT cat data files (csv/parquet/json/sqlite) — that bypasses the privacy boundary.
+- **bash(command)** — runs a shell command in the workspace (cwd pinned), killed after 30s, output capped at 64KB. Use for git, ls, build commands, ad-hoc orchestration. Do NOT cat data files (csv/parquet/json/sqlite) — that bypasses the privacy boundary. NEVER read qwery's own state under \`~/.qwery\` (master key, qwery.sqlite, config) — it is sandboxed and holds encrypted credentials; to inspect or test a datasource use the datasource tools, never raw SQL against qwery.sqlite.
 - **read(path)** — reads a UTF-8 file from the workspace (up to 64KB). Use for scripts, configs, READMEs, schema definitions. Do NOT read data files — use schema/runQuery/present instead.
 - **write(path, content)** — writes a UTF-8 file inside the workspace (up to 1MB). Use to save scripts, configs, generated artifacts.
 

--- a/packages/agent-factory-sdk/src/system-tools.ts
+++ b/packages/agent-factory-sdk/src/system-tools.ts
@@ -1,16 +1,58 @@
 import { spawn } from 'node:child_process';
-import { promises as fs } from 'node:fs';
+import { existsSync, promises as fs } from 'node:fs';
 import { homedir } from 'node:os';
 import path from 'node:path';
 
+const HOME = homedir();
 const WORKSPACE_ROOT = process.cwd();
-const CACHE_ROOT = path.join(homedir(), '.qwery', 'cache');
+/** qwery's private state dir: master key, persistence DB, config. */
+const QWERY_HOME = path.join(HOME, '.qwery');
+const CACHE_ROOT = path.join(QWERY_HOME, 'cache');
 const ALLOWED_ROOTS = [WORKSPACE_ROOT, CACHE_ROOT];
 
 export const BASH_TIMEOUT_MS = 30_000;
 export const BASH_MAX_OUTPUT_BYTES = 64 * 1024;
 export const READ_MAX_BYTES = 64 * 1024;
 export const WRITE_MAX_BYTES = 1_000_000;
+
+/**
+ * `~/.qwery` holds the AES master key, the persistence DB (encrypted datasource
+ * credentials), and config. `bash` must never touch it: otherwise the LLM can
+ * exfiltrate the very secrets the vault exists to hide (read the master key +
+ * the ciphertext + the open-source algorithm = full decryption). The `read`
+ * tool already refuses these paths via `resolveSafePath`; `bash` needs its own
+ * guard. The cache subdir stays accessible. Agents must use the datasource and
+ * GFS tools instead of poking qwery's internals.
+ */
+const QWERY_GUARD_MESSAGE =
+  "bash: access to qwery's private directory (~/.qwery) is blocked — it holds the master key and encrypted datasource credentials. Never read it. Use the datasource tools (datasourceList / datasourceTest / datasourceAttach) and the GFS tools instead.";
+
+/**
+ * Best-effort static guard, applied on every platform. It is the only FS guard
+ * where the OS sandbox is unavailable (non-darwin), and defense-in-depth where
+ * it is. Matches references to `~/.qwery` (absolute, `~`, or `$HOME`) that are
+ * not the cache subdir, plus the master key by name.
+ */
+export function assertBashCommandAllowed(command: string): void {
+  const refsQweryPrivate =
+    /\.qwery\/(?!cache(?:\/|\b))/.test(command) || /\.qwery\/?(?:\s|$|;|&|\|)/.test(command);
+  const refsMasterKey = /\.master\.key\b/.test(command);
+  if (refsQweryPrivate || refsMasterKey) throw new Error(QWERY_GUARD_MESSAGE);
+}
+
+/**
+ * macOS kernel-enforced sandbox profile: allow everything, then deny read+write
+ * on `~/.qwery` while re-allowing its `cache` subdir. Unlike the static guard,
+ * this cannot be bypassed with env vars, encoding, or indirection. Linux
+ * hardening (bubblewrap) is a follow-up; until then the static guard stands.
+ */
+const SANDBOX_AVAILABLE = process.platform === 'darwin' && existsSync('/usr/bin/sandbox-exec');
+const SANDBOX_PROFILE = [
+  '(version 1)',
+  '(allow default)',
+  `(deny file-read* file-write* (subpath "${QWERY_HOME}"))`,
+  `(allow file-read* file-write* (subpath "${CACHE_ROOT}"))`,
+].join('\n');
 
 /**
  * Resolve a user-supplied path inside one of the allowed roots (workspace or
@@ -37,12 +79,20 @@ export interface BashResult {
  * Run a shell command via `bash -c`. We pass the command as a single argument
  * to spawn (not interpolated into another string) so user-supplied content can
  * never break the argv boundary. `cwd` is pinned to the workspace and the
- * process is killed after `BASH_TIMEOUT_MS`. ADR #18 — MVP scope: no FS or
- * process sandbox yet, only argv-level injection safety + timeout + cwd lock.
+ * process is killed after `BASH_TIMEOUT_MS`.
+ *
+ * FS access to `~/.qwery` (secrets) is blocked two ways: a static guard
+ * (`assertBashCommandAllowed`, every platform) and, on macOS, a kernel-enforced
+ * `sandbox-exec` profile. The command otherwise has normal filesystem access so
+ * legitimate tooling (git, bun, build steps) keeps working (ADR #18).
  */
 export async function runBash(command: string): Promise<BashResult> {
+  assertBashCommandAllowed(command);
+  const [bin, args] = SANDBOX_AVAILABLE
+    ? (['sandbox-exec', ['-p', SANDBOX_PROFILE, 'bash', '-c', command]] as const)
+    : (['bash', ['-c', command]] as const);
   return new Promise((resolvePromise, reject) => {
-    const child = spawn('bash', ['-c', command], { cwd: WORKSPACE_ROOT });
+    const child = spawn(bin, args, { cwd: WORKSPACE_ROOT });
     const stdoutChunks: Buffer[] = [];
     const stderrChunks: Buffer[] = [];
     let stdoutBytes = 0;

--- a/packages/agent-factory-sdk/src/system-tools.ts
+++ b/packages/agent-factory-sdk/src/system-tools.ts
@@ -43,8 +43,7 @@ export function assertBashCommandAllowed(command: string): void {
 /**
  * macOS kernel-enforced sandbox profile: allow everything, then deny read+write
  * on `~/.qwery` while re-allowing its `cache` subdir. Unlike the static guard,
- * this cannot be bypassed with env vars, encoding, or indirection. Linux
- * hardening (bubblewrap) is a follow-up; until then the static guard stands.
+ * this cannot be bypassed with env vars, encoding, or indirection.
  */
 const SANDBOX_AVAILABLE = process.platform === 'darwin' && existsSync('/usr/bin/sandbox-exec');
 const SANDBOX_PROFILE = [
@@ -53,6 +52,44 @@ const SANDBOX_PROFILE = [
   `(deny file-read* file-write* (subpath "${QWERY_HOME}"))`,
   `(allow file-read* file-write* (subpath "${CACHE_ROOT}"))`,
 ].join('\n');
+
+/**
+ * Linux kernel-enforced equivalent via bubblewrap: pass the whole filesystem
+ * through (`--dev-bind / /`) so legitimate tooling keeps working, then overlay
+ * an empty tmpfs on `~/.qwery` to hide the master key / DB / config, re-binding
+ * only the `cache` subdir. Mirrors the macOS deny.
+ */
+const BWRAP_BIN = '/usr/bin/bwrap';
+
+export function bwrapArgs(command: string): string[] {
+  const args = ['--dev-bind', '/', '/', '--tmpfs', QWERY_HOME];
+  if (existsSync(CACHE_ROOT)) args.push('--bind', CACHE_ROOT, CACHE_ROOT);
+  args.push('--', 'bash', '-c', command);
+  return args;
+}
+
+/**
+ * Probe bwrap once, memoized. We don't just check the binary exists: user
+ * namespaces are disabled on some kernels and inside some containers, and the
+ * recipe must actually run. So we run the real recipe on a trivial command and
+ * verify its output. If anything fails, we fall back to the static guard only
+ * (no regression — bwrap is used only where it provably works).
+ */
+let bwrapProbe: Promise<boolean> | null = null;
+function detectBwrap(): Promise<boolean> {
+  if (process.platform !== 'linux' || !existsSync(BWRAP_BIN)) return Promise.resolve(false);
+  if (bwrapProbe) return bwrapProbe;
+  bwrapProbe = new Promise<boolean>((resolveProbe) => {
+    let out = '';
+    const probe = spawn(BWRAP_BIN, bwrapArgs("printf '__bwrap_ok__'"));
+    probe.stdout.on('data', (c: Buffer) => {
+      out += c.toString('utf-8');
+    });
+    probe.on('error', () => resolveProbe(false));
+    probe.on('close', (code) => resolveProbe(code === 0 && out.includes('__bwrap_ok__')));
+  });
+  return bwrapProbe;
+}
 
 /**
  * Resolve a user-supplied path inside one of the allowed roots (workspace or
@@ -82,15 +119,22 @@ export interface BashResult {
  * process is killed after `BASH_TIMEOUT_MS`.
  *
  * FS access to `~/.qwery` (secrets) is blocked two ways: a static guard
- * (`assertBashCommandAllowed`, every platform) and, on macOS, a kernel-enforced
- * `sandbox-exec` profile. The command otherwise has normal filesystem access so
- * legitimate tooling (git, bun, build steps) keeps working (ADR #18).
+ * (`assertBashCommandAllowed`, every platform) and a kernel-enforced sandbox —
+ * `sandbox-exec` on macOS, bubblewrap on Linux when available. The command
+ * otherwise has normal filesystem access so legitimate tooling (git, bun, build
+ * steps) keeps working (ADR #18).
  */
 export async function runBash(command: string): Promise<BashResult> {
   assertBashCommandAllowed(command);
-  const [bin, args] = SANDBOX_AVAILABLE
-    ? (['sandbox-exec', ['-p', SANDBOX_PROFILE, 'bash', '-c', command]] as const)
-    : (['bash', ['-c', command]] as const);
+  let bin = 'bash';
+  let args: string[] = ['-c', command];
+  if (SANDBOX_AVAILABLE) {
+    bin = 'sandbox-exec';
+    args = ['-p', SANDBOX_PROFILE, 'bash', '-c', command];
+  } else if (await detectBwrap()) {
+    bin = BWRAP_BIN;
+    args = bwrapArgs(command);
+  }
   return new Promise((resolvePromise, reject) => {
     const child = spawn(bin, args, { cwd: WORKSPACE_ROOT });
     const stdoutChunks: Buffer[] = [];

--- a/packages/agent-factory-sdk/src/system-tools.ts
+++ b/packages/agent-factory-sdk/src/system-tools.ts
@@ -5,10 +5,41 @@ import path from 'node:path';
 
 const HOME = homedir();
 const WORKSPACE_ROOT = process.cwd();
-/** qwery's private state dir: master key, persistence DB, config. */
+/** qwery's private state dir: master key, persistence DB, config, plus benign subdirs. */
 const QWERY_HOME = path.join(HOME, '.qwery');
-const CACHE_ROOT = path.join(QWERY_HOME, 'cache');
-const ALLOWED_ROOTS = [WORKSPACE_ROOT, CACHE_ROOT];
+/**
+ * Subdirs of `~/.qwery` that ARE legitimate for tools to read: user-authored
+ * agent assets (skills, agents, commands, hooks, prompts, templates, plugins,
+ * output-styles, themes, statusline), the analysis cache, and logs. Listing
+ * here is deny-by-default + allowlist — everything else under `~/.qwery` stays
+ * blocked, so a new file never leaks by omission.
+ *
+ * NEVER add a name that can hold secrets or the user's data. Off-limits, even
+ * though they are "agent" dirs:
+ *   - config.json / settings.json / settings.local.json (env, keys, perms)
+ *   - mcp.json / mcp/ (MCP server env tokens — classic leak vector)
+ *   - sessions/ projects/ history/ transcripts/ conversations/ (chat logs:
+ *     secrets the user typed in other sessions)
+ *   - storage/ (artifacts = query results = row-level data, ADR #28)
+ *   - credentials/ auth/ tokens/ keys/, .master.key, *.sqlite*, anonymous-id
+ *   - memory/ (handled separately — do not allowlist here)
+ */
+const QWERY_OPEN_SUBDIRS = [
+  'cache',
+  'skills',
+  'agents',
+  'logs',
+  'commands',
+  'hooks',
+  'prompts',
+  'templates',
+  'output-styles',
+  'themes',
+  'statusline',
+  'plugins',
+] as const;
+const QWERY_OPEN_PATHS = QWERY_OPEN_SUBDIRS.map((d) => path.join(QWERY_HOME, d));
+const ALLOWED_ROOTS = [WORKSPACE_ROOT, ...QWERY_OPEN_PATHS];
 
 export const BASH_TIMEOUT_MS = 30_000;
 export const BASH_MAX_OUTPUT_BYTES = 64 * 1024;
@@ -17,53 +48,55 @@ export const WRITE_MAX_BYTES = 1_000_000;
 
 /**
  * `~/.qwery` holds the AES master key, the persistence DB (encrypted datasource
- * credentials), and config. `bash` must never touch it: otherwise the LLM can
- * exfiltrate the very secrets the vault exists to hide (read the master key +
- * the ciphertext + the open-source algorithm = full decryption). The `read`
- * tool already refuses these paths via `resolveSafePath`; `bash` needs its own
- * guard. The cache subdir stays accessible. Agents must use the datasource and
- * GFS tools instead of poking qwery's internals.
+ * credentials), config, and the telemetry id. `bash` must never read those:
+ * otherwise the LLM can exfiltrate the very secrets the vault exists to hide
+ * (master key + ciphertext + open-source algorithm = full decryption). Benign
+ * subdirs (skills/agents/cache/logs) stay accessible so the agent can `read`
+ * user-level skills and agents. Deny-by-default, allowlist the benign.
  */
-const QWERY_GUARD_MESSAGE =
-  "bash: access to qwery's private directory (~/.qwery) is blocked — it holds the master key and encrypted datasource credentials. Never read it. Use the datasource tools (datasourceList / datasourceTest / datasourceAttach) and the GFS tools instead.";
+const QWERY_GUARD_MESSAGE = `bash: access to qwery's private files under ~/.qwery is blocked — they hold the master key and encrypted datasource credentials. Use the datasource tools (datasourceList / datasourceTest / datasourceAttach) and the GFS tools instead. (Reading ~/.qwery/{${QWERY_OPEN_SUBDIRS.join(',')}} is allowed.)`;
 
 /**
  * Best-effort static guard, applied on every platform. It is the only FS guard
  * where the OS sandbox is unavailable (non-darwin), and defense-in-depth where
- * it is. Matches references to `~/.qwery` (absolute, `~`, or `$HOME`) that are
- * not the cache subdir, plus the master key by name.
+ * it is. Blocks references to `~/.qwery` that are NOT one of the benign subdirs,
+ * plus the master key by name.
  */
 export function assertBashCommandAllowed(command: string): void {
+  const benign = QWERY_OPEN_SUBDIRS.join('|');
   const refsQweryPrivate =
-    /\.qwery\/(?!cache(?:\/|\b))/.test(command) || /\.qwery\/?(?:\s|$|;|&|\|)/.test(command);
+    new RegExp(`\\.qwery\\/(?!(?:${benign})(?:\\/|\\b))`).test(command) ||
+    /\.qwery\/?(?:\s|$|;|&|\|)/.test(command);
   const refsMasterKey = /\.master\.key\b/.test(command);
   if (refsQweryPrivate || refsMasterKey) throw new Error(QWERY_GUARD_MESSAGE);
 }
 
 /**
- * macOS kernel-enforced sandbox profile: allow everything, then deny read+write
- * on `~/.qwery` while re-allowing its `cache` subdir. Unlike the static guard,
- * this cannot be bypassed with env vars, encoding, or indirection.
+ * macOS kernel-enforced sandbox profile: allow everything, deny read+write on
+ * `~/.qwery`, then re-allow the benign subdirs. Unlike the static guard, this
+ * cannot be bypassed with env vars, encoding, or indirection.
  */
 const SANDBOX_AVAILABLE = process.platform === 'darwin' && existsSync('/usr/bin/sandbox-exec');
 const SANDBOX_PROFILE = [
   '(version 1)',
   '(allow default)',
   `(deny file-read* file-write* (subpath "${QWERY_HOME}"))`,
-  `(allow file-read* file-write* (subpath "${CACHE_ROOT}"))`,
+  ...QWERY_OPEN_PATHS.map((p) => `(allow file-read* file-write* (subpath "${p}"))`),
 ].join('\n');
 
 /**
  * Linux kernel-enforced equivalent via bubblewrap: pass the whole filesystem
  * through (`--dev-bind / /`) so legitimate tooling keeps working, then overlay
- * an empty tmpfs on `~/.qwery` to hide the master key / DB / config, re-binding
- * only the `cache` subdir. Mirrors the macOS deny.
+ * an empty tmpfs on `~/.qwery` to hide the secrets, re-binding the benign
+ * subdirs. Mirrors the macOS deny.
  */
 const BWRAP_BIN = '/usr/bin/bwrap';
 
 export function bwrapArgs(command: string): string[] {
   const args = ['--dev-bind', '/', '/', '--tmpfs', QWERY_HOME];
-  if (existsSync(CACHE_ROOT)) args.push('--bind', CACHE_ROOT, CACHE_ROOT);
+  for (const p of QWERY_OPEN_PATHS) {
+    if (existsSync(p)) args.push('--bind', p, p);
+  }
   args.push('--', 'bash', '-c', command);
   return args;
 }
@@ -92,17 +125,16 @@ function detectBwrap(): Promise<boolean> {
 }
 
 /**
- * Resolve a user-supplied path inside one of the allowed roots (workspace or
- * `~/.qwery/cache`). Throws if the resolved path escapes both roots. ADR #18.
+ * Resolve a user-supplied path inside one of the allowed roots: the workspace,
+ * or the benign `~/.qwery` subdirs (cache, skills, agents, logs). Throws if the
+ * resolved path escapes them all — notably qwery's secrets. ADR #18.
  */
 export function resolveSafePath(input: string): string {
   const resolved = path.resolve(WORKSPACE_ROOT, input);
   for (const root of ALLOWED_ROOTS) {
     if (resolved === root || resolved.startsWith(root + path.sep)) return resolved;
   }
-  throw new Error(
-    `Path "${input}" resolves outside the workspace and cache roots. Allowed roots: ${ALLOWED_ROOTS.join(', ')}`,
-  );
+  throw new Error(`Path "${input}" resolves outside the allowed roots. Allowed: ${ALLOWED_ROOTS.join(', ')}`);
 }
 
 export interface BashResult {


### PR DESCRIPTION
Durcissement sécurité issu de l'audit GFS : empêcher l'agent d'exfiltrer les secrets (les captures montraient `sqlite3 ~/.qwery/qwery.sqlite` et `cat ~/.qwery/config.json` pour récupérer des credentials).

## 1. Sandbox du tool `bash`
`bash` ne sandboxait que son `cwd`. Désormais, accès FS à `~/.qwery` bloqué par **deux couches** :
- **guard statique** (toutes plateformes) — rejette avant spawn ;
- **sandbox noyau** : `sandbox-exec` (macOS) + `bubblewrap` (Linux, sonde auto-protectrice avec fallback sans régression).

## 2. Allowlist des dossiers bénins (deny-by-default)
Modèle unique `QWERY_OPEN_SUBDIRS` appliqué à `read` + guard bash + sandbox macOS + bwrap : `cache, skills, agents, logs, commands, hooks, prompts, templates, output-styles, themes, statusline, plugins` sont lisibles (skills/agents user-level que l'agent doit `read`). Tout le reste sous `~/.qwery` reste refusé. Les noms **sensibles** (config/settings, `mcp`, `sessions/projects/transcripts`, `storage`, credentials, `*.sqlite*`, `memory`) sont documentés comme à ne jamais ouvrir.

## 3. Clé maître → trousseau OS (ADR #19)
La clé AES était en clair dans `~/.qwery/.master.key`. Déplacée dans le trousseau (`security` macOS / `secret-tool` Linux), fallback fichier sinon. **Migration sûre** : import de la clé existante puis suppression du fichier **uniquement** après write+readback vérifié (jamais de perte de clé). Pas d'addon natif (shell-out) pour préserver `bun build --compile`.

## Vérifications
- 817 tests (45 system-tools : guard/allowlist/bwrap ; 5 secret-vault : fallback/round-trip/migration/échec/priorité), `tsc -b`, `check:arch`, `bun run lint` — verts.
- Validations runtime réelles : exploit des captures bloqué (statique), chemin obfusqué refusé (noyau), skills lisibles, contrat `security` CLI vérifié en live.

## Suivi (hors PR)
- test d'intégration gated des adaptateurs `security`/`secret-tool` (paramétrer service/account) ;
- `memory/` traitée séparément.

🤖 Generated with [Claude Code](https://claude.com/claude-code)