### PR TITLE
feat(context): break down /context by skills, subagents and prompt blocks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ apps/e2e/artifacts/
 
 # TS incremental build info
 *.tsbuildinfo
+
+# Local GFS repositories (versioned DB sandbox, provisioned per directory)
+.gfs/

--- a/apps/cli/src/app.tsx
+++ b/apps/cli/src/app.tsx
@@ -134,6 +134,7 @@ export function App() {
   const [overlayContextSnapshot, setOverlayContextSnapshot] = useState<{
     apps: import('@qwery/agent-factory-sdk').LocalAppSummary[];
     skills: import('@qwery/agent-factory-sdk').SkillSummary[];
+    subagents: import('@qwery/agent-factory-sdk').SubagentInfo[];
   } | null>(null);
   const [attachStates, setAttachStates] = useState<AttachState[]>([]);
   const [pinnedAgent, setPinnedAgent] = useState<AgentId | null>(null);
@@ -658,9 +659,10 @@ export function App() {
       }
       if (text === '/context') {
         void (async () => {
-          const [appsForCtx, skillsForCtx] = await Promise.all([
+          const [appsForCtx, skillsForCtx, subagentsForCtx] = await Promise.all([
             listLocalApps().catch(() => []),
             listLocalSkills().catch(() => [] as LocalSkillSummary[]),
+            listLocalSubagents().catch(() => []),
           ]);
           setOverlayContextSnapshot({
             apps: appsForCtx,
@@ -669,6 +671,11 @@ export function App() {
               description: s.description,
               path: s.path,
               agent: s.agent,
+            })),
+            subagents: subagentsForCtx.map((sa) => ({
+              name: sa.name,
+              description: sa.description,
+              baseAgent: sa.baseAgent,
             })),
           });
           setOverlay('context');
@@ -1011,6 +1018,7 @@ export function App() {
         datasources={datasourceSummaries}
         apps={overlayContextSnapshot.apps}
         skills={overlayContextSnapshot.skills}
+        subagents={overlayContextSnapshot.subagents}
         loadedTools={[...loadedTools.current]}
         onClose={() => {
           setOverlay(null);

--- a/apps/cli/src/tui/context-overlay.tsx
+++ b/apps/cli/src/tui/context-overlay.tsx
@@ -1,9 +1,11 @@
 import {
   type AgentSpec,
   type AttachedDatasourceSummary,
-  buildSystemPrompt,
   type LocalAppSummary,
   type SkillSummary,
+  type SubagentInfo,
+  SYSTEM_PROMPT,
+  systemPromptSegments,
 } from '@qwery/agent-factory-sdk';
 import type { ModelMessage } from 'ai';
 import { Box, Text, useInput } from 'ink';
@@ -18,8 +20,15 @@ interface ContextOverlayProps {
   datasources: AttachedDatasourceSummary[];
   apps: LocalAppSummary[];
   skills: SkillSummary[];
+  subagents: SubagentInfo[];
   loadedTools: string[];
   onClose: () => void;
+}
+
+/** A labelled token line inside the System-prompt breakdown. */
+interface PromptPart {
+  label: string;
+  tokens: number;
 }
 
 interface Category {
@@ -88,6 +97,7 @@ export function ContextOverlay({
   datasources,
   apps,
   skills,
+  subagents,
   loadedTools,
   onClose,
 }: ContextOverlayProps) {
@@ -97,15 +107,28 @@ export function ContextOverlay({
 
   const limit = contextLimit ?? 200_000;
 
-  const categories = useMemo<Category[]>(() => {
-    // System prompt with the same context blocks runAgent injects.
-    const fullPrompt = buildSystemPrompt({
+  const scopedSkills = useMemo(
+    () => skills.filter((s) => !s.agent || s.agent === 'all' || s.agent === agent.id),
+    [skills, agent],
+  );
+
+  const { categories, promptParts } = useMemo(() => {
+    // Same dynamic blocks runAgent injects, but attributed per segment so the
+    // System-prompt total breaks down into base + skills + subagents + …
+    const segments = systemPromptSegments({
       datasources,
       apps,
-      skills: skills.filter((s) => !s.agent || s.agent === 'all' || s.agent === agent.id),
+      skills: scopedSkills,
+      subagents,
       agentPreamble: agent.promptPreamble,
     });
-    const promptTokens = tokensOf(fullPrompt);
+    const baseTokens = tokensOf(SYSTEM_PROMPT);
+    const parts: PromptPart[] = [{ label: 'base prompt', tokens: baseTokens }];
+    for (const seg of segments) {
+      const suffix = seg.key === 'preamble' ? '' : ` (${seg.count})`;
+      parts.push({ label: `${seg.label.toLowerCase()}${suffix}`, tokens: tokensOf(seg.text) });
+    }
+    const promptTokens = parts.reduce((acc, p) => acc + p.tokens, 0);
 
     // Active tool roster = agent's core tools + 3 navigators + already-loaded.
     const activeTools = new Set<string>([
@@ -120,12 +143,13 @@ export function ContextOverlay({
 
     const messageTokens = estimateMessageTokens(messages);
 
-    return [
+    const cats: Category[] = [
       { key: 'prompt', label: 'System prompt', color: 'cyan', tokens: promptTokens },
       { key: 'tools', label: 'Active tools', color: 'magenta', tokens: toolTokens },
       { key: 'messages', label: 'Messages', color: 'green', tokens: messageTokens },
     ];
-  }, [agent, datasources, apps, skills, loadedTools, messages]);
+    return { categories: cats, promptParts: parts };
+  }, [agent, datasources, apps, scopedSkills, subagents, loadedTools, messages]);
 
   const used = categories.reduce((acc, c) => acc + c.tokens, 0);
   const free = Math.max(0, limit - used);
@@ -218,10 +242,30 @@ export function ContextOverlay({
       </Box>
 
       <Box marginTop={1} flexDirection="column">
+        <Text bold>System prompt breakdown</Text>
+        {promptParts.map((p) => (
+          <Box key={p.label}>
+            <Text dimColor>{`  ${p.label}`.padEnd(22)}</Text>
+            <Text dimColor>
+              {fmt(p.tokens).padStart(6)} ({pct(p.tokens)})
+            </Text>
+          </Box>
+        ))}
+      </Box>
+
+      <Box marginTop={1} flexDirection="column">
         <Text dimColor>Active agent: {agent.label}</Text>
         <Text dimColor>
           Last turn input: {fmt(lastTurnInputTokens)} tokens
           {contextLimit ? ` (${pct(lastTurnInputTokens)})` : ''}
+        </Text>
+        <Text dimColor>
+          Skills ({scopedSkills.length}):{' '}
+          {scopedSkills.length > 0 ? scopedSkills.map((s) => s.name).join(', ') : 'none'}
+        </Text>
+        <Text dimColor>
+          Subagents ({subagents.length}):{' '}
+          {subagents.length > 0 ? subagents.map((s) => s.name).join(', ') : 'none'}
         </Text>
         {loadedTools.length > 0 && <Text dimColor>Loaded lazy tools: {loadedTools.join(', ')}</Text>}
       </Box>

--- a/packages/agent-factory-sdk/src/__tests__/system-prompt.test.ts
+++ b/packages/agent-factory-sdk/src/__tests__/system-prompt.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, test } from 'bun:test';
-import { buildSystemPrompt, SYSTEM_PROMPT } from '../system-prompt';
+import { buildSystemPrompt, SYSTEM_PROMPT, systemPromptSegments } from '../system-prompt';
 
 describe('buildSystemPrompt', () => {
   test('returns SYSTEM_PROMPT unchanged when no context is provided', () => {
@@ -89,5 +89,33 @@ describe('buildSystemPrompt', () => {
     });
     expect(out).toContain('sql-optimizer [data] — Optimises SQL');
     expect(out).toContain('reviewer — Reviews diffs');
+  });
+});
+
+describe('systemPromptSegments', () => {
+  test('returns no segments for an empty context', () => {
+    expect(systemPromptSegments()).toEqual([]);
+  });
+
+  test('reports each block with its key and item count, joining back to buildSystemPrompt', () => {
+    const ctx = {
+      agentPreamble: 'You are the data agent.',
+      skills: [
+        { name: 'a', description: 'da', path: '/a' },
+        { name: 'b', description: 'db', path: '/b' },
+      ],
+      subagents: [{ name: 'x', description: 'dx' }],
+      apps: [{ slug: 'dash', files: ['index.html'], truncated: false }],
+    };
+    const segs = systemPromptSegments(ctx);
+    const byKey = Object.fromEntries(segs.map((s) => [s.key, s]));
+    expect(byKey.preamble?.count).toBe(1);
+    expect(byKey.subagents?.count).toBe(1);
+    expect(byKey.skills?.count).toBe(2);
+    expect(byKey.apps?.count).toBe(1);
+    expect(byKey.datasources).toBeUndefined(); // none provided
+
+    // The segments joined with the base prompt reconstruct buildSystemPrompt.
+    expect(`${segs.map((s) => s.text).join('\n\n')}\n\n${SYSTEM_PROMPT}`).toBe(buildSystemPrompt(ctx));
   });
 });

--- a/packages/agent-factory-sdk/src/index.ts
+++ b/packages/agent-factory-sdk/src/index.ts
@@ -35,8 +35,12 @@ export {
   buildSystemPrompt,
   type LocalAppSummary,
   type SkillSummary,
+  type SubagentInfo,
   SYSTEM_PROMPT,
   type SystemPromptContext,
+  type SystemPromptSegment,
+  type SystemPromptSegmentKey,
+  systemPromptSegments,
 } from './system-prompt';
 export { buildTodoTools, createTodoStore, type TodoStore } from './todo-tools';
 export {

--- a/packages/agent-factory-sdk/src/system-prompt.ts
+++ b/packages/agent-factory-sdk/src/system-prompt.ts
@@ -112,14 +112,25 @@ export interface SystemPromptContext {
   agentPreamble?: string;
 }
 
+export type SystemPromptSegmentKey = 'preamble' | 'subagents' | 'skills' | 'datasources' | 'apps';
+
+export interface SystemPromptSegment {
+  key: SystemPromptSegmentKey;
+  label: string;
+  /** Number of items the segment lists (subagents, skills, datasources, apps). */
+  count: number;
+  text: string;
+}
+
 /**
- * Build the system prompt with two dynamic prefixes:
- *   - Attached datasources: column metadata only, never row values (ADR #28).
- *   - Existing local apps under `apps/<slug>/`: slugs + immediate file lists so
- *     the LLM can update an existing app without re-asking the user for paths.
+ * The dynamic blocks prepended to SYSTEM_PROMPT, in order. Exposed so callers
+ * (e.g. the /context overlay) can attribute prompt tokens per block without
+ * duplicating the formatting — `buildSystemPrompt` joins these with the base
+ * prompt. Same dynamic prefixes as before: datasources expose column metadata
+ * only, never row values (ADR #28); apps expose slugs + immediate file lists.
  */
-export function buildSystemPrompt(context: SystemPromptContext = {}): string {
-  const blocks: string[] = [];
+export function systemPromptSegments(context: SystemPromptContext = {}): SystemPromptSegment[] {
+  const segments: SystemPromptSegment[] = [];
   const datasources = context.datasources ?? [];
   const apps = context.apps ?? [];
   const skills = context.skills ?? [];
@@ -130,7 +141,7 @@ export function buildSystemPrompt(context: SystemPromptContext = {}): string {
   const subagents = context.subagents;
   const preamble = context.agentPreamble?.trim();
 
-  if (preamble) blocks.push(preamble);
+  if (preamble) segments.push({ key: 'preamble', label: 'Agent preamble', count: 1, text: preamble });
 
   if (subagents !== undefined) {
     const lines: string[] = [
@@ -148,7 +159,7 @@ export function buildSystemPrompt(context: SystemPromptContext = {}): string {
     lines.push(
       'Ad-hoc: omit `name` and pass `prompt` (the subagent role), optional `baseAgent` ("data"|"code"), and optional `tools` whitelist. Use this for one-off delegations that do not warrant a persisted file.',
     );
-    blocks.push(lines.join('\n'));
+    segments.push({ key: 'subagents', label: 'Subagents', count: subagents.length, text: lines.join('\n') });
   }
 
   if (skills.length > 0) {
@@ -158,7 +169,7 @@ export function buildSystemPrompt(context: SystemPromptContext = {}): string {
     for (const skill of skills) {
       lines.push(`- ${skill.name} — ${skill.description} (file: ${skill.path})`);
     }
-    blocks.push(lines.join('\n'));
+    segments.push({ key: 'skills', label: 'Skills', count: skills.length, text: lines.join('\n') });
   }
 
   if (datasources.length > 0) {
@@ -175,7 +186,12 @@ export function buildSystemPrompt(context: SystemPromptContext = {}): string {
         lines.push(`- ${ds.name} (${ds.provider}): ${t.path} — columns: ${cols}`);
       }
     }
-    blocks.push(lines.join('\n'));
+    segments.push({
+      key: 'datasources',
+      label: 'Datasources',
+      count: datasources.length,
+      text: lines.join('\n'),
+    });
   }
 
   if (apps.length > 0) {
@@ -186,9 +202,15 @@ export function buildSystemPrompt(context: SystemPromptContext = {}): string {
       const fileList = app.files.length === 0 ? '(empty)' : app.files.join(', ');
       lines.push(`- apps/${app.slug}/ — ${fileList}${app.truncated ? ' …' : ''}`);
     }
-    blocks.push(lines.join('\n'));
+    segments.push({ key: 'apps', label: 'Apps', count: apps.length, text: lines.join('\n') });
   }
 
+  return segments;
+}
+
+/** Build the full system prompt: dynamic segments joined with the base prompt. */
+export function buildSystemPrompt(context: SystemPromptContext = {}): string {
+  const blocks = systemPromptSegments(context).map((s) => s.text);
   if (blocks.length === 0) return SYSTEM_PROMPT;
   return `${blocks.join('\n\n')}\n\n${SYSTEM_PROMPT}`;
 }


### PR DESCRIPTION
L'overlay `/context` montrait le system prompt comme **un seul chiffre opaque**. Il **ventile** désormais ces tokens par bloc — base prompt, **skills (N)**, **subagents (M)**, datasources, apps — et **liste les skills et subagents chargés**, pour voir le coût de chacun.

## Changements
- **agent-factory-sdk** : extraction de `systemPromptSegments(context)` comme **source unique** des blocs dynamiques du prompt ; `buildSystemPrompt` ne fait que les joindre avec le prompt de base (sortie **inchangée**, couverte par les tests existants). Pas de duplication de format → pas de dérive.
- **context-overlay** : reçoit `subagents` (auparavant omis → l'estimation du prompt sous-comptait aussi), affiche le breakdown + les noms des skills/subagents chargés.
- **app.tsx** : charge les subagents dans le snapshot `/context` et les transmet.

## Vérifs
880 tests (+ `systemPromptSegments`), `tsc -b`, dep-cruiser, biome — verts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)