### PR TITLE
feat(datasource): random default names and a rename action in the TUI

### DIFF
--- a/apps/cli/src/infra/random-name.ts
+++ b/apps/cli/src/infra/random-name.ts
@@ -1,0 +1,48 @@
+// Friendly, human-readable default names for datasources, in the same
+// adjective-noun-suffix shape db-audit uses (e.g. `misty-river-a8b2c1`).
+// Memorable and collision-resistant enough for a default the user can rename.
+
+const ADJECTIVES = [
+  'misty',
+  'silent',
+  'quiet',
+  'bright',
+  'dark',
+  'mysterious',
+  'ancient',
+  'quick',
+  'lazy',
+  'wild',
+  'fierce',
+  'happy',
+  'gentle',
+  'bold',
+  'calm',
+];
+
+const NOUNS = [
+  'sound',
+  'forest',
+  'river',
+  'mountain',
+  'valley',
+  'ocean',
+  'sky',
+  'star',
+  'moon',
+  'sun',
+  'wind',
+  'storm',
+  'rain',
+  'cloud',
+  'shadow',
+];
+
+function pick<T>(items: readonly T[]): T {
+  return items[Math.floor(Math.random() * items.length)]!;
+}
+
+export function generateRandomName(): string {
+  const suffix = Math.random().toString(36).slice(2, 8);
+  return `${pick(ADJECTIVES)}-${pick(NOUNS)}-${suffix}`;
+}

--- a/apps/cli/src/tui/datasources-overlay.tsx
+++ b/apps/cli/src/tui/datasources-overlay.tsx
@@ -4,6 +4,7 @@ import { type DatasourceExtension, ExtensionsRegistry } from '@qwery/extension-s
 import { Box, Text, useInput } from 'ink';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import type { AttachState } from '../infra/datasources';
+import { generateRandomName } from '../infra/random-name';
 import { useServices } from '../services';
 
 interface DatasourcesOverlayProps {
@@ -32,6 +33,7 @@ type Mode =
   | { kind: 'pick-extension'; cursor: number }
   | { kind: 'pick-variant'; extension: DatasourceExtension; variants: Variant[]; cursor: number }
   | { kind: 'confirm-delete'; datasource: Datasource; cursor: number }
+  | { kind: 'rename'; datasource: Datasource; cursor: number; buffer: string; error?: string }
   | {
       kind: 'configure';
       extension: DatasourceExtension;
@@ -255,6 +257,34 @@ export function DatasourcesOverlay({ onClose, onAttached }: DatasourcesOverlayPr
         void toggleProjectAttach(selectedDs);
       } else if (input === 'd' && selectedDs) {
         setMode({ kind: 'confirm-delete', datasource: selectedDs, cursor: mode.cursor });
+      } else if (input === 'r' && selectedDs) {
+        // `r` renames the selected datasource, pre-filling its current name.
+        setMode({ kind: 'rename', datasource: selectedDs, cursor: mode.cursor, buffer: selectedDs.name });
+      }
+      return;
+    }
+
+    if (mode.kind === 'rename') {
+      const m = mode;
+      if (key.return) {
+        const trimmed = m.buffer.trim();
+        if (trimmed.length === 0) {
+          setMode({ ...m, error: 'Name is required' });
+          return;
+        }
+        if (trimmed === m.datasource.name) {
+          setMode({ kind: 'list', cursor: m.cursor });
+          return;
+        }
+        void renameDatasource(m.datasource, trimmed, m.cursor);
+        return;
+      }
+      if (key.backspace || key.delete) {
+        setMode({ ...m, buffer: m.buffer.slice(0, -1), error: undefined });
+        return;
+      }
+      if (input && !key.ctrl && !key.meta) {
+        setMode({ ...m, buffer: m.buffer + input, error: undefined });
       }
       return;
     }
@@ -348,6 +378,21 @@ export function DatasourcesOverlay({ onClose, onAttached }: DatasourcesOverlayPr
     }
   });
 
+  async function renameDatasource(ds: Datasource, name: string, cursor: number): Promise<void> {
+    try {
+      await DatasourceUseCases.updateDatasource({ datasourceRepo }, ds.id, { name });
+      const refreshed = await datasourceRepo.findAll();
+      setDatasources(refreshed);
+      await refreshProjects(refreshed);
+      setMode({ kind: 'list', cursor });
+      setStatus(`Renamed ${ds.name} → ${name}`);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error('datasource.rename.error', { id: ds.id, message });
+      setMode({ kind: 'rename', datasource: ds, cursor, buffer: name, error: message });
+    }
+  }
+
   async function submit(
     extension: DatasourceExtension,
     fields: FormField[],
@@ -371,7 +416,9 @@ export function DatasourcesOverlay({ onClose, onAttached }: DatasourcesOverlayPr
       const ds = await DatasourceUseCases.createDatasource(
         { datasourceRepo },
         {
-          name: extension.name,
+          // New datasources get a friendly random name by default; the user
+          // can rename it from the list with `r`.
+          name: generateRandomName(),
           description: extension.description ?? '',
           datasource_provider: extension.id,
           datasource_driver: driverReg.id,
@@ -405,7 +452,9 @@ export function DatasourcesOverlay({ onClose, onAttached }: DatasourcesOverlayPr
                 ? `Connect ${mode.extension.name}`
                 : mode.kind === 'confirm-delete'
                   ? `Delete ${mode.datasource.name}?`
-                  : `Configure ${mode.extension.name}`}
+                  : mode.kind === 'rename'
+                    ? `Rename ${mode.datasource.name}`
+                    : `Configure ${mode.extension.name}`}
         </Text>
         <Text dimColor>esc {mode.kind === 'list' ? 'close' : 'back'}</Text>
       </Box>
@@ -429,6 +478,7 @@ export function DatasourcesOverlay({ onClose, onAttached }: DatasourcesOverlayPr
       {mode.kind === 'pick-extension' && <PickExtensionMode extensions={extensions} cursor={mode.cursor} />}
       {mode.kind === 'pick-variant' && <PickVariantMode mode={mode} />}
       {mode.kind === 'confirm-delete' && <ConfirmDeleteMode datasource={mode.datasource} />}
+      {mode.kind === 'rename' && <RenameMode mode={mode} />}
       {mode.kind === 'configure' && <ConfigureMode mode={mode} />}
     </Box>
   );
@@ -453,7 +503,9 @@ function ListMode({
   return (
     <Box flexDirection="column">
       <Box marginY={1} flexDirection="column">
-        <Text dimColor>↑/↓ navigate · n new · a attach/detach · p project · d delete · esc close</Text>
+        <Text dimColor>
+          ↑/↓ navigate · n new · a attach/detach · p project · r rename · d delete · esc close
+        </Text>
         <Text dimColor>
           showing {scopeLabel} · t: {showAll ? 'this project only' : 'show all'}
         </Text>
@@ -581,6 +633,36 @@ function ConfirmDeleteMode({ datasource }: { datasource: Datasource }) {
         <Text bold>n</Text>
         <Text dimColor> / enter / esc cancel</Text>
       </Box>
+    </Box>
+  );
+}
+
+function RenameMode({ mode }: { mode: Extract<Mode, { kind: 'rename' }> }) {
+  return (
+    <Box flexDirection="column">
+      <Box marginY={1}>
+        <Text dimColor>enter to save · esc cancel</Text>
+      </Box>
+      <Box>
+        <Text bold>Name: </Text>
+      </Box>
+      <Box>
+        <Text color="magenta" bold>
+          ›{' '}
+        </Text>
+        <Text>{mode.buffer}</Text>
+        <Text inverse> </Text>
+      </Box>
+      <Box marginTop={1}>
+        <Text dimColor>
+          {mode.datasource.name} <Text dimColor>({mode.datasource.datasource_provider})</Text>
+        </Text>
+      </Box>
+      {mode.error && (
+        <Box marginTop={1}>
+          <Text color="red">{mode.error}</Text>
+        </Box>
+      )}
     </Box>
   );
 }

--- a/apps/e2e/src/__snapshots__/slash-overlays.e2e.test.tsx.snap
+++ b/apps/e2e/src/__snapshots__/slash-overlays.e2e.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`e2e: Tier 3 slash commands (overlays) /datasources opens the datasource
 │                                                                                                  │
 │ Datasources                                                                            esc close │
 │                                                                                                  │
-│ ↑/↓ navigate · n new · a attach/detach · p project · d delete · esc close                        │
+│ ↑/↓ navigate · n new · a attach/detach · p project · r rename · d delete · esc close             │
 │ showing project · t: show all                                                                    │
 │                                                                                                  │
 │ No datasources in project. Press \`n\` to add one, or \`t\` to see all and \`p\` to attach.            │


### PR DESCRIPTION
## Related Issue
N/A (no linked issue)

## What
The datasources TUI overlay had two gaps: every new datasource was named after its extension (so multiple Postgres sources all read `PostgreSQL`), and there was no way to rename one once created. This adds friendly random default names and an in-overlay rename action.

## How
- Added `apps/cli/src/infra/random-name.ts` with `generateRandomName()`, producing an `adjective-noun-suffix` name (e.g. `misty-river-a8b2c1`), matching the scheme used in db-audit. No new dependency — inline word lists plus a base-36 suffix.
- `submit()` in the overlay now assigns `generateRandomName()` instead of `extension.name` when creating a datasource.
- Added a `rename` mode to the overlay state machine, reachable with `r` from the list. It opens a single-field editor pre-filled with the current name and persists via the existing `Datasource.updateDatasource` use case (previously unused in the TUI). Empty names are rejected; an unchanged name is a no-op.
- Updated the list hint line and the e2e overlay snapshot accordingly.

## Review Guide
1. `apps/cli/src/infra/random-name.ts` — the name generator.
2. `apps/cli/src/tui/datasources-overlay.tsx` — `rename` mode, `r` handler, `renameDatasource()`, and the default-name change in `submit()`.
3. `apps/e2e/src/__snapshots__/slash-overlays.e2e.test.tsx.snap` — hint-line snapshot update only.

## Testing
- [x] Manual testing performed
- [ ] Unit tests added/updated
- [x] E2E tests added/updated (snapshot)

Ran locally:
- `bun run typecheck` — passes
- `bun test` — 845 pass, 0 fail
- `bun run lint:fix` — passes (only pre-existing repo-wide `noNonNullAssertion` warnings)

## Documentation
- [x] Code comments added for complex logic
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)

## User Impact
- New datasources get a unique, memorable default name instead of colliding on the extension name.
- Datasources can be renamed from the overlay with `r`.
- No breaking changes.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`bun test`)
- [x] Lint passes (`bun run lint:fix`)
- [x] Type check passes (`bun run typecheck`)
- [x] This PR can be safely reverted if needed