### PR TITLE
fix(tui): lay the status bar out on two lines so it stops wrapping in split view

### DIFF
--- a/apps/cli/src/tui/__tests__/status-bar.test.tsx
+++ b/apps/cli/src/tui/__tests__/status-bar.test.tsx
@@ -1,0 +1,58 @@
+import { describe, expect, test } from 'bun:test';
+import { Box } from 'ink';
+import { render } from 'ink-testing-library';
+import { EMPTY_SESSION_TOTALS, StatusBar, type StatusBarProps } from '../status-bar';
+import { plain } from './_ansi';
+
+const baseProps = (over: Partial<StatusBarProps> = {}): StatusBarProps => ({
+  providerLabel: 'Azure OpenAI · gpt-5.3-codex',
+  totals: EMPTY_SESSION_TOTALS,
+  contextLimit: 400_000,
+  lastTurnInputTokens: 0,
+  attachedDatasources: 0,
+  agentLabel: 'DataAgent',
+  agentPinned: false,
+  ...over,
+});
+
+// Render inside a fixed-width column to reproduce the split-layout squeeze.
+function rows(props: StatusBarProps, width: number): string[] {
+  const { lastFrame } = render(
+    <Box width={width}>
+      <StatusBar {...props} />
+    </Box>,
+  );
+  return plain(lastFrame())
+    .split('\n')
+    .filter((l) => l.trim().length > 0);
+}
+
+describe('StatusBar', () => {
+  test('puts the provider label and the indicators on separate rows', () => {
+    const out = rows(baseProps(), 50);
+    expect(out.length).toBe(2);
+    expect(out[0]).toContain('gpt-5.3-codex');
+    expect(out[0]).toContain('400k ctx');
+    expect(out[1]).toContain('DataAgent');
+  });
+
+  test('stays two rows in a narrow column instead of wrapping mid-word', () => {
+    // Regression: the indicators defaulted to wrap="wrap" and broke onto a
+    // third line ("⟳ update rea" + "dy") when the column was too narrow.
+    const out = rows(
+      baseProps({
+        updateReady: true,
+        attachedDatasources: 2,
+        totals: { inputTokens: 12_000, outputTokens: 3400, totalTokens: 15_400, costUSD: 0.12 },
+        lastTurnInputTokens: 8000,
+      }),
+      48,
+    );
+    expect(out.length).toBe(2);
+  });
+
+  test('falls back to a no-provider hint when none is configured', () => {
+    const out = rows(baseProps({ providerLabel: null, contextLimit: null }), 50);
+    expect(out[0]).toContain('no provider · /models');
+  });
+});

--- a/apps/cli/src/tui/status-bar.tsx
+++ b/apps/cli/src/tui/status-bar.tsx
@@ -81,50 +81,81 @@ export function StatusBar({
     : 'no provider · /models';
 
   return (
-    <Box paddingX={1}>
-      <Text dimColor wrap="truncate-end">
-        {labelWithCtx}
-      </Text>
-      <Box marginLeft={2}>
-        <Text color="magenta" bold>
-          {agentLabel}
+    <Box flexDirection="column" paddingX={1}>
+      {/* Two rows so the bar fits the half-width column in split layout (UI
+          decision U1) without the indicators wrapping mid-word: the label owns
+          row 1, the right-aligned indicators own row 2 and truncate not wrap. */}
+      <Box>
+        <Text dimColor wrap="truncate-end">
+          {labelWithCtx}
         </Text>
-        {agentPinned && <Text dimColor> ·pinned</Text>}
       </Box>
-      <Box flexGrow={1} />
-      {updateReady && (
-        <Box marginRight={2}>
-          <Text color="yellow">⟳ update ready</Text>
-          <Text dimColor> · /update</Text>
-        </Box>
-      )}
-      {todos && todos.total > 0 && (
-        <Box marginRight={2}>
-          <Text color={todos.open > 0 ? 'yellow' : 'green'}>
-            ☐ {todos.total - todos.open}/{todos.total}
+      <Box>
+        <Box flexShrink={1} minWidth={0}>
+          <Text color="magenta" bold wrap="truncate-end">
+            {agentLabel}
           </Text>
-          <Text dimColor> todos</Text>
+          {agentPinned && (
+            <Text dimColor wrap="truncate-end">
+              {' '}
+              ·pinned
+            </Text>
+          )}
         </Box>
-      )}
-      {attachedDatasources > 0 && (
-        <Box marginRight={2}>
-          <Text color="green">🛢 {attachedDatasources}</Text>
-          <Text dimColor> {attachedDatasources === 1 ? 'datasource' : 'datasources'}</Text>
-        </Box>
-      )}
-      {contextLimit && lastTurnInputTokens > 0 && (
-        <Box marginRight={2}>
-          <ContextBar used={lastTurnInputTokens} limit={contextLimit} />
-        </Box>
-      )}
-      {hasUsage ? (
-        <Text dimColor>
-          ↓ {fmtTokens(totals.inputTokens)} · ↑ {fmtTokens(totals.outputTokens)} ·{' '}
-          <Text color="cyan">{fmtCost(totals.costUSD)}</Text>
-        </Text>
-      ) : (
-        <Text dimColor>ready</Text>
-      )}
+        <Box flexGrow={1} />
+        {updateReady && (
+          <Box marginLeft={2} flexShrink={0}>
+            <Text color="yellow" wrap="truncate-end">
+              ⟳ update ready
+            </Text>
+            <Text dimColor wrap="truncate-end">
+              {' '}
+              · /update
+            </Text>
+          </Box>
+        )}
+        {todos && todos.total > 0 && (
+          <Box marginLeft={2} flexShrink={0}>
+            <Text color={todos.open > 0 ? 'yellow' : 'green'} wrap="truncate-end">
+              ☐ {todos.total - todos.open}/{todos.total}
+            </Text>
+            <Text dimColor wrap="truncate-end">
+              {' '}
+              todos
+            </Text>
+          </Box>
+        )}
+        {attachedDatasources > 0 && (
+          <Box marginLeft={2} flexShrink={0}>
+            <Text color="green" wrap="truncate-end">
+              🛢 {attachedDatasources}
+            </Text>
+            <Text dimColor wrap="truncate-end">
+              {' '}
+              {attachedDatasources === 1 ? 'datasource' : 'datasources'}
+            </Text>
+          </Box>
+        )}
+        {contextLimit && lastTurnInputTokens > 0 && (
+          <Box marginLeft={2} flexShrink={0}>
+            <ContextBar used={lastTurnInputTokens} limit={contextLimit} />
+          </Box>
+        )}
+        {hasUsage ? (
+          <Box marginLeft={2} flexShrink={0}>
+            <Text dimColor wrap="truncate-end">
+              ↓ {fmtTokens(totals.inputTokens)} · ↑ {fmtTokens(totals.outputTokens)} ·{' '}
+              <Text color="cyan">{fmtCost(totals.costUSD)}</Text>
+            </Text>
+          </Box>
+        ) : (
+          <Box marginLeft={2} flexShrink={0}>
+            <Text dimColor wrap="truncate-end">
+              ready
+            </Text>
+          </Box>
+        )}
+      </Box>
     </Box>
   );
 }

--- a/apps/e2e/src/__snapshots__/chat-persist.e2e.test.tsx.snap
+++ b/apps/e2e/src/__snapshots__/chat-persist.e2e.test.tsx.snap
@@ -26,9 +26,9 @@ exports[`e2e: chat turn persists to a real sqlite DB a prompt + mock reply are w
                                                   │
                                                   │
                                                   │
-                                                  │
  ╭──────────────────────────────────────────────╮ │
  │ ›                                            │ │
  ╰──────────────────────────────────────────────╯ │
-  no provider · /models  DataAgent        ready   │"
+  no provider · /models                           │
+  DataAgent                                ready  │"
 `;

--- a/apps/e2e/src/__snapshots__/slash-basic.e2e.test.tsx.snap
+++ b/apps/e2e/src/__snapshots__/slash-basic.e2e.test.tsx.snap
@@ -26,11 +26,11 @@ exports[`e2e: Tier 1 slash commands /help → "Slash commands:" 1`] = `
                                                   │
                                                   │
                                                   │
-                                                  │
  ╭──────────────────────────────────────────────╮ │
  │ ›                                            │ │
  ╰──────────────────────────────────────────────╯ │
-  no provider · /models  DataAgent        ready   │"
+  no provider · /models                           │
+  DataAgent                                ready  │"
 `;
 
 exports[`e2e: Tier 1 slash commands /data → "Agent routing pinned to: DataAgent." 1`] = `
@@ -59,11 +59,11 @@ exports[`e2e: Tier 1 slash commands /data → "Agent routing pinned to: DataAgen
                                                   │
                                                   │
                                                   │
-                                                  │
  ╭──────────────────────────────────────────────╮ │
  │ ›                                            │ │
  ╰──────────────────────────────────────────────╯ │
-  no provider · /models  DataAgent ·pinnedready   │"
+  no provider · /models                           │
+  DataAgent ·pinned                        ready  │"
 `;
 
 exports[`e2e: Tier 1 slash commands /code → "Agent routing pinned to: CodingAgent." 1`] = `
@@ -95,8 +95,8 @@ exports[`e2e: Tier 1 slash commands /code → "Agent routing pinned to: CodingAg
  ╭──────────────────────────────────────────────╮ │
  │ ›                                            │ │
  ╰──────────────────────────────────────────────╯ │
-  no provider · /models CodingAgen ·pinnedready   │
-                                                  │"
+  no provider · /models                           │
+  CodingAgent ·pinned                      ready  │"
 `;
 
 exports[`e2e: Tier 1 slash commands /auto → "Agent routing pinned to: auto (heuristic)." 1`] = `
@@ -125,9 +125,9 @@ exports[`e2e: Tier 1 slash commands /auto → "Agent routing pinned to: auto (he
                                                   │
                                                   │
                                                   │
-                                                  │
  ╭──────────────────────────────────────────────╮ │
  │ ›                                            │ │
  ╰──────────────────────────────────────────────╯ │
-  no provider · /models  DataAgent        ready   │"
+  no provider · /models                           │
+  DataAgent                                ready  │"
 `;

--- a/apps/e2e/src/__snapshots__/slash-state.e2e.test.tsx.snap
+++ b/apps/e2e/src/__snapshots__/slash-state.e2e.test.tsx.snap
@@ -26,11 +26,11 @@ exports[`e2e: Tier 2 slash commands /layout toggles split → focus (TabBar appe
 
 
 
-
  ╭────────────────────────────────────────────────────────────────────────────────────────────────╮
  │ ›                                                                                              │
  ╰────────────────────────────────────────────────────────────────────────────────────────────────╯
-  no provider · /models  DataAgent                                                           ready"
+  no provider · /models
+  DataAgent                                                                                  ready"
 `;
 
 exports[`e2e: Tier 2 slash commands /clear removes prior chat entries 1`] = `
@@ -59,9 +59,9 @@ exports[`e2e: Tier 2 slash commands /clear removes prior chat entries 1`] = `
                                                   │
                                                   │
                                                   │
-                                                  │
  ╭──────────────────────────────────────────────╮ │
  │ ›                                            │ │
  ╰──────────────────────────────────────────────╯ │
-  no provider · /models  DataAgent        ready   │"
+  no provider · /models                           │
+  DataAgent                                ready  │"
 `;


### PR DESCRIPTION
## Related Issue
N/A — UI polish spotted while running the dev TUI.

## What
In split layout the status bar is rendered inside the **left half-width column** (`app.tsx`), so its single row was wider than the space available. Because the right-side `<Text>` segments had no `wrap` prop they defaulted to `wrap="wrap"` and broke onto a second line mid-word (`⟳ update ready` → `update rea` + `t`), while the provider/model label was truncated down to almost nothing (`gpt-5.3-codex (40…`).

## How
Reworked `StatusBar` into a two-row layout:

- **Line 1** — the provider/model label gets the full column width to itself, so it no longer over-truncates.
- **Line 2** — the session indicators (agent label, update-ready, todos, datasources, ctx bar, usage/`ready`) sit on their own row. The agent label can shrink/truncate; every right-side segment is `flexShrink={0}` + `wrap="truncate-end"` and is pushed right by a flex spacer, so the row stays on a single line and clips cleanly instead of wrapping.

Trade-off: costs one extra terminal row. The alternative (moving the bar out of the split column into a full-width footer) was considered but is a larger layout refactor.

## Review Guide
1. `apps/cli/src/tui/status-bar.tsx` — the layout change.
2. The three `apps/e2e/src/__snapshots__/*.snap` files — regenerated to reflect the two-line bar (diffs are only the status-bar rows).

## Testing
- [x] Manual testing performed (verified in the dev TUI, split view)
- [x] Unit tests added/updated (e2e snapshots regenerated)
- [ ] E2E tests added/updated

## Documentation
- [ ] Code comments added for complex logic (added brief line-1/line-2 comments)
- [ ] README or docs updated if needed
- [ ] CHANGELOG.md updated (if applicable)

## User Impact
- The status bar reads cleanly in split view: the model name is fully visible and indicators no longer wrap mid-word.
- No breaking changes. Uses one additional terminal row.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Tests pass locally (`bun test`)
- [x] Lint passes (`bun run lint:fix`)
- [x] Type check passes (`bun run typecheck`)
- [x] This PR can be safely reverted if needed
